### PR TITLE
Fix TFClient by removing, rather than adding, a leading '/' character in TFClient.processFeedback()

### DIFF
--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -45,8 +45,8 @@ ROSLIB.TFClient.prototype.processFeedback = function(tf) {
   var that = this;
   tf.transforms.forEach(function(transform) {
     var frameID = transform.child_frame_id;
-    if (frameID[0] !== '/') {
-      frameID = '/' + frameID;
+    if (frameID[0] === '/') {
+      frameID = frameID.substring(1);
     }
     var info = that.frameInfos[frameID];
     if (info !== undefined) {


### PR DESCRIPTION
Fixes issue #78

This is in accordance with both the [hydro migration guidelines](http://wiki.ros.org/hydro/Migration#tf2.2BAC8-Migration.Removal_of_support_for_tf_prefix) and the implementation of TFClient.subscribe() (TFClient.js:102)
