### PR TITLE
add a bower.json to publish this as a Bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "roslibjs",
+  "description": "roslibjs is the core JavaScript library for interacting with ROS from the browser. It uses WebSockets to connect with rosbridge and provides publishing, subscribing, service calls, actionlib, TF, URDF parsing, and other essential ROS functionality. roslibjs is developed as part of the Robot Web Tools effort.",
+  "version": "0.9.0",
+  "homepage": "https://github.com/RobotWebTools/roslibjs",
+  "authors": [
+    "Russell Toris<rctoris@wpi.edu>",
+    "Jihoon Lee <jihoonlee.in@gmail.com>",
+    "Brandon Alexander <balexander@willowgarage.com>",
+    "David Gossow <dgossow@willowgarage.com>",
+    "Benjamin Pitzer <ben.pitzer@gmail.com>"
+  ],
+  "main": "build/roslib.js",
+  "license": "BSD",
+  "ignore": [
+    "bower_components",
+    "doc",
+    "examples",
+    "include",
+    "node_modules",
+    "src",
+    "test",
+    "utils"
+  ],
+  "dependencies": {
+    "eventemitter2": "0.4.11"
+  }
+}


### PR DESCRIPTION
Bower is a package manager for the web. It makes installing front end libraries extremely easy:
`bower install roslibjs`

I created a bower.json with meta data such that bower knows about the dependencies of roslibjs. You can try this out by running the following command, it will install both roslibjs and EventEmitter2.
`bower install Rayman/roslibjs#develop`

In issue #80 we discussed this and concluded that bower needs a master branch. Now that we have a master branch, the bower.json can be integrated. I put the version at 0.9.0 so that it can be included in the next release.
