### PR TITLE
Replace xmldom dep with xmlshim. Remove xpath dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "roslib",
+  "name": "roslibjs",
   "description": "The standard ROS Javascript Library",
   "homepage": "https://www.robotwebtools.org",
   "version": "0.8.3",
@@ -11,11 +11,10 @@
     "robot"
   ],
   "dependencies": {
-    "nodejs-websocket": "~0.1.4",
-    "eventemitter2": "~0.4.13",
     "canvas": "~1.1.3",
-    "xpath": "~0.0.6",
-    "xmldom": "~0.1.19"
+    "eventemitter2": "~0.4.13",
+    "nodejs-websocket": "~0.1.4",
+    "xmlshim": "0.0.9"
   },
   "scripts": {
     "publish": "grunt build",

--- a/src/RosLibHeader.js
+++ b/src/RosLibHeader.js
@@ -23,9 +23,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2;
 var ws = require('nodejs-websocket');
 var Canvas = require('canvas');
 var Image = Canvas.Image;
-var DOMParser = require('xmldom').DOMParser;
-var XPath = require('xpath');
-var XPathResult = require('xpath').XPathResult;
+var DOMParser = require('xmlshim').DOMParser;
 
 /**
  * Provides a WebSocket browser compatible interface to the nodejs-websocket client library. This is used by ROSLIB.Ros directly.

--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -3,6 +3,9 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
+// See https://developer.mozilla.org/docs/XPathResult#Constants
+var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
+
 /**
  * A URDF Model can be used to parse a given URDF into the appropriate elements.
  *
@@ -26,14 +29,8 @@ ROSLIB.UrdfModel = function(options) {
    */
   var initXml = function(xmlDoc) {
     // Get the robot tag
+    var robotXml = xmlDoc.evaluate('//robot', xmlDoc, null, XPATH_FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 
-    var robotXml;
-    if( typeof( XPath ) === 'undefined' ){
-      robotXml = xmlDoc.evaluate('//robot', xmlDoc, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-    }else{
-      // Node JS
-      robotXml = XPath.select('//robot', xmlDoc)[0];
-    }
     // Get the robot name
     that.name = robotXml.getAttribute('name');
 

--- a/test/urdf.test.js
+++ b/test/urdf.test.js
@@ -1,6 +1,10 @@
 var expect = require('chai').expect;
 var ROSLIB = require('..');
 
+var DOMParser = require('xmlshim').DOMParser;
+// See https://developer.mozilla.org/docs/XPathResult#Constants
+var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
+
 var sample_urdf = function (){
   return '<robot name="test_robot">' +
     '  <link name="link1" />'+
@@ -32,6 +36,13 @@ describe('URDF', function() {
       });
 
       expect(urdfModel.name).to.equal('test_robot');
+    });
+
+    it('is ignorant to the xml node', function(){
+      var parser = new DOMParser();
+      var xml = parser.parseFromString(sample_urdf(), 'text/xml');
+      var robotXml = xml.evaluate('//robot', xml, null, XPATH_FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      expect(robotXml.getAttribute('name')).to.equal('test_robot');
     });
   });
 


### PR DESCRIPTION
[xmlshim](https://github.com/znerol/node-xmlshim) aligns much better with the standard `DOMParser` API then `xmldom`. Allows us to use the same code in  `src/urdf/UrdfModel.js` for both node and browser.

I removed a dependency by hard coding a constant (See https://developer.mozilla.org/docs/XPathResult#Constants)
