### PR TITLE
Alternative syntax for create Topics, Services, Params, etc

### DIFF
--- a/src/RosLib.js
+++ b/src/RosLib.js
@@ -6,7 +6,7 @@ var ROSLIB = this.ROSLIB || {
   REVISION : '0.10.0-SNAPSHOT'
 };
 
-ROSLIB.Ros = require('./core/Ros');
+var Ros = ROSLIB.Ros = require('./core/Ros');
 ROSLIB.Topic = require('./core/Topic');
 ROSLIB.Message = require('./core/Message');
 ROSLIB.Param = require('./core/Param');
@@ -37,5 +37,13 @@ ROSLIB.UrdfVisual = require('./urdf/UrdfVisual');
 
 // Add URDF types
 require('object-assign')(ROSLIB, require('./urdf/UrdfTypes'));
+
+['ActionClient', 'Param', 'Service', 'SimpleActionServer', 'Topic', 'TFClient'].forEach(function(className) {
+    var Class = ROSLIB[className];
+    Ros.prototype[className] = function(options) {
+        options.ros = this;
+        return new Class(options);
+    };
+});
 
 module.exports = ROSLIB;

--- a/test/examples/tf.example.js
+++ b/test/examples/tf.example.js
@@ -20,4 +20,23 @@ describe('TF2 Republisher Example', function() {
             done();
         });
     });
+
+    it('tf republisher alternative syntax', function(done) {
+        var ros = new ROSLIB.Ros({
+            url: 'ws://localhost:9090'
+        });
+
+        var tfClient = ros.TFClient({
+            fixedFrame: 'world',
+            angularThres: 0.01,
+            transThres: 0.01
+        });
+
+        // Subscribe to a turtle.
+        tfClient.subscribe('turtle1', function(tf) {
+            expect(tf.rotation).to.be.eql(new ROSLIB.Quaternion());
+            expect(tf.translation).to.be.a.instanceof(ROSLIB.Vector3);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
A little sugar in the bowl... Simple patch to make creating topics, services, params and clients less verbose

``` js
var ros = new ROSLIB.Ros({
    url : 'ws://localhost:9090'
});

// Current
var maxVelX = new ROSLIB.Param({
    ros : ros,
    name : 'max_vel_y'
});

// Optionally, after this patch
var maxVelX = ros.Param({
    name : 'max_vel_y'
});
```
