### PR TITLE
add 'time-grunt' and improve the Gruntfile.js a bit

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,15 @@
+'use strict';
+
 module.exports = function(grunt) {
 
-  var package = grunt.file.readJSON('package.json');
+  // Time how long tasks take. Can help when optimizing build times
+  require('time-grunt')(grunt);
+
+  // Load grunt tasks automatically
+  require('load-grunt-tasks')(grunt);
+
   grunt.initConfig({
-    pkg: package,
+    pkg: grunt.file.readJSON('package.json'),
     browserify: {
       dist: {
         src: ['./src/RosLibBrowser.js'],
@@ -85,12 +92,6 @@ module.exports = function(grunt) {
       }
     }
   });
-
-  for (var dep in package.devDependencies) {
-    if (dep.slice(0, 6) === 'grunt-') {
-      grunt.loadNpmTasks(dep);
-    }
-  }
 
   grunt.registerTask('dev', ['browserify', 'watch']);
   grunt.registerTask('test', ['jshint', 'mochaTest:test', 'browserify', 'karma']);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "grunt-mocha-test": "^0.11.0",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.1.9",
-    "karma-firefox-launcher": "~0.1.3"
+    "karma-firefox-launcher": "~0.1.3",
+    "load-grunt-tasks": "^0.6.0",
+    "time-grunt": "^1.0.0"
   },
   "dependencies": {
     "canvas": "1.1.3",


### PR DESCRIPTION
The Gruntfile now shows time graphs after a build has been done. It also uses 'load-grunt-tasks' for loading grunt tasks. For reference, these two modules are also used in the official [yeoman/generator-webapp](https://github.com/yeoman/generator-webapp).

I also added 'use strict' to enable strict mode. This prohibits the use of the variable 'package' so I inlined that bit.
