### PR TITLE
rename roslibjs to roslib to match up with npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "roslibjs",
+  "name": "roslib",
   "description": "roslibjs is the core JavaScript library for interacting with ROS from the browser. It uses WebSockets to connect with rosbridge and provides publishing, subscribing, service calls, actionlib, TF, URDF parsing, and other essential ROS functionality. roslibjs is developed as part of the Robot Web Tools effort.",
   "version": "0.10.0",
   "homepage": "https://github.com/RobotWebTools/roslibjs",


### PR DESCRIPTION
@Rayman @rctoris Please review this. I have renamed bowers module name as `roslib` to match with module name in npm.
