### PR TITLE
Added queue_length parameter to topic subscription message

### DIFF
--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -72,7 +72,8 @@ Topic.prototype.subscribe = function(callback) {
     type: this.messageType,
     topic: this.name,
     compression: this.compression,
-    throttle_rate: this.throttle_rate
+    throttle_rate: this.throttle_rate,
+    queue_length: this.queue_size
   });
 };
 


### PR DESCRIPTION
As mentionned in issue #163, Rosbridge_suite expects queue_length parameter on subscription to handle queues. Queue_size was not passed until now. This fixes it.