### PR TITLE
remove the (unused) DOMParser shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "aliases": {
       "canvas": "./src/util/shim/canvas.js",
       "eventemitter2": "./src/util/shim/EventEmitter2.js",
-      "ws": "./src/util/shim/WebSocket.js",
-      "./src/util/DOMParser.js": "./src/util/shim/DOMParser.js"
+      "ws": "./src/util/shim/WebSocket.js"
     }
   },
   "directories": {

--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -6,7 +6,7 @@
 var UrdfMaterial = require('./UrdfMaterial');
 var UrdfLink = require('./UrdfLink');
 var UrdfJoint = require('./UrdfJoint');
-var DOMParser = require('../util/DOMParser');
+var DOMParser = require('xmlshim').DOMParser;
 
 // See https://developer.mozilla.org/docs/XPathResult#Constants
 var XPATH_FIRST_ORDERED_NODE_TYPE = 9;

--- a/src/util/DOMParser.js
+++ b/src/util/DOMParser.js
@@ -1,1 +1,0 @@
-module.exports = require('xmlshim').DOMParser;

--- a/src/util/shim/DOMParser.js
+++ b/src/util/shim/DOMParser.js
@@ -1,1 +1,0 @@
-module.exports = global.DOMParser;

--- a/test/require-shim.js
+++ b/test/require-shim.js
@@ -1,6 +1,7 @@
 window.require = function require(path) {
 	switch (path) {
 		case 'eventemitter2': return {EventEmitter2: EventEmitter2};
+		case 'xmlshim': return {DOMParser: DOMParser}
 	}
 	var lastIdx = path.lastIndexOf('/'),
 		path = lastIdx >= 0 ? path.slice(lastIdx + 1) : path;

--- a/test/urdf.test.js
+++ b/test/urdf.test.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect;
 var ROSLIB = require('..');
 
-var DOMParser = typeof DOMParser == 'function' ? DOMParser : require('../src/util/DOMParser');
+var DOMParser = require('xmlshim').DOMParser;
 // See https://developer.mozilla.org/docs/XPathResult#Constants
 var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
 


### PR DESCRIPTION
The current DOMParser shim is not used, you can verify this by fixing the `package.json`:
```
"../util/DOMParser": "./src/util/shim/DOMParser.js"
```

The `xmlshim` package provides its own shim (which is already used in the roslibjs build). This pull request makes it more clear which shim is used.