### PR TITLE
Change dependencies to allow building with node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "dependencies": {
     "aliasify-patch": "^1.4.1",
-    "canvas": "1.1.3",
+    "canvas": ">=1.1.3",
     "eventemitter2": "~0.4.13",
     "object-assign": "^2.0.0",
     "ws": "^0.4.32",
-    "xmlshim": "~0.0.9"
+    "xmlshim": "https://github.com/galvanix/node-xmlshim/tarball/greenfelt"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This is to solve Issue #160 

I freely admit this may not be the best way to deal with the issue, but it works for me and has been working since July 1st, although there may be parts of the code that I don't use.

Feel free to reject this and implement a better solution.