### PR TITLE
replace xmlshim with xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.3.1",
     "grunt-jsdoc": "~0.6.0",
-    "grunt-karma": "^0.9.0",
+    "grunt-karma": "^0.12.0",
     "grunt-mocha-test": "^0.11.0",
     "karma-chai": "^0.1.0",
     "karma-firefox-launcher": "~0.1.3",
@@ -28,7 +28,7 @@
     "eventemitter2": "~0.4.13",
     "object-assign": "^2.0.0",
     "ws": "^0.4.32",
-    "xmlshim": "~0.0.9"
+    "xmldom": "^0.1.19"
   },
   "browserify": {
     "transform": [
@@ -39,7 +39,8 @@
     "aliases": {
       "canvas": "./src/util/shim/canvas.js",
       "eventemitter2": "./src/util/shim/EventEmitter2.js",
-      "ws": "./src/util/shim/WebSocket.js"
+      "ws": "./src/util/shim/WebSocket.js",
+      "xmldom": "./src/util/shim/xmldom.js"
     }
   },
   "directories": {

--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -6,7 +6,7 @@
 var UrdfMaterial = require('./UrdfMaterial');
 var UrdfLink = require('./UrdfLink');
 var UrdfJoint = require('./UrdfJoint');
-var DOMParser = require('xmlshim').DOMParser;
+var DOMParser = require('xmldom').DOMParser;
 
 // See https://developer.mozilla.org/docs/XPathResult#Constants
 var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
@@ -36,7 +36,7 @@ function UrdfModel(options) {
 
   // Initialize the model with the given XML node.
   // Get the robot tag
-  var robotXml = xmlDoc.evaluate('//robot', xmlDoc, null, XPATH_FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+  var robotXml = xmlDoc.documentElement;
 
   // Get the robot name
   this.name = robotXml.getAttribute('name');

--- a/src/util/shim/xmldom.js
+++ b/src/util/shim/xmldom.js
@@ -1,0 +1,3 @@
+exports.DOMImplementation = global.DOMImplementation;
+exports.XMLSerializer = global.XMLSerializer;
+exports.DOMParser = global.DOMParser;

--- a/test/require-shim.js
+++ b/test/require-shim.js
@@ -1,7 +1,7 @@
 window.require = function require(path) {
 	switch (path) {
 		case 'eventemitter2': return {EventEmitter2: EventEmitter2};
-		case 'xmlshim': return {DOMParser: DOMParser}
+		case 'xmldom': return {DOMParser: DOMParser}
 	}
 	var lastIdx = path.lastIndexOf('/'),
 		path = lastIdx >= 0 ? path.slice(lastIdx + 1) : path;

--- a/test/urdf.test.js
+++ b/test/urdf.test.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect;
 var ROSLIB = require('..');
 
-var DOMParser = require('xmlshim').DOMParser;
+var DOMParser = require('xmldom').DOMParser;
 // See https://developer.mozilla.org/docs/XPathResult#Constants
 var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
 
@@ -114,7 +114,7 @@ describe('URDF', function() {
     it('is ignorant to the xml node', function(){
       var parser = new DOMParser();
       var xml = parser.parseFromString(sample_urdf(), 'text/xml');
-      var robotXml = xml.evaluate('//robot', xml, null, XPATH_FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+      var robotXml = xml.documentElement;
       expect(robotXml.getAttribute('name')).to.equal('test_robot');
     });
   });


### PR DESCRIPTION
xmldom is a full JavaScript implementation of DOMParser with the same functionality. It is a lot more used and so I think it is more reliable (217.411 downloads in the last week vs 88).

As a result this project will no longer depend on libxmljs which makes it easier to install on platforms such as windows. All tests on both node and browser still run.

As a side effect I had to reintroduce `shim/xmldom.js` to keep the build size small. I also replaced the xpath `evaluate` call with `documentElement` because we no longer have that. Could that become a problem?