### PR TITLE
canvas version bump to use for both node version 0.10.x and 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "aliasify-patch": "^1.4.1",
-    "canvas": "1.1.3",
+    "canvas": "~1.2.8",
     "eventemitter2": "~0.4.13",
     "object-assign": "^2.0.0",
     "ws": "^0.4.32",


### PR DESCRIPTION
This addresses #187 and #189. 