### PR TITLE
Add options to omit the feedback, status or result channel of ActionClient.

### DIFF
--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -51,7 +51,9 @@ function TFClient(options) {
   // Create an Action client
   this.actionClient = this.ros.ActionClient({
     serverName : this.serverName,
-    actionName : 'tf2_web_republisher/TFSubscriptionAction'
+    actionName : 'tf2_web_republisher/TFSubscriptionAction',
+    omitStatus : true,
+    omitResult : true
   });
 
   // Create a Service client


### PR DESCRIPTION
Omitting certain channels of the action client will make the action protocol incomplete. However, this can reduce the network load of the websocket and the action protocol will still work in certain use cases.