### PR TITLE
Added repubServiceName parameter to TFClient.

### DIFF
--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -25,6 +25,8 @@ var Transform = require('../math/Transform');
  *                   to update the TF republisher's list of TFs
  *   * topicTimeout - the timeout parameter for the TF republisher
  *   * serverName (optional) - the name of the tf2_web_republisher server
+ *   * repubServiceName (optional) - the name of the republish_tfs service (non groovy compatibility mode only)
+ *   																 default: '/republish_tfs'
  */
 function TFClient(options) {
   options = options || {};
@@ -42,6 +44,7 @@ function TFClient(options) {
     nsecs: nsecs
   };
   this.serverName = options.serverName || '/tf2_web_republisher';
+  this.repubServiceName = options.repubServiceName || '/republish_tfs';
 
   this.currentGoal = false;
   this.currentTopic = false;
@@ -58,7 +61,7 @@ function TFClient(options) {
 
   // Create a Service client
   this.serviceClient = this.ros.Service({
-    name: '/republish_tfs',
+    name: this.repubServiceName,
     serviceType: 'tf2_web_republisher/RepublishTFs'
   });
 }


### PR DESCRIPTION
This parameter is needed if your tf2_web_republisher is running in a namesspace.