### PR TITLE
An action listener for all actions not just for goals created by client

### DIFF
--- a/src/actionlib/ActionListener.js
+++ b/src/actionlib/ActionListener.js
@@ -1,0 +1,87 @@
+/**
+ * @fileOverview
+ * @author Justin Young - justin@oodar.com.au
+ * @author Russell Toris - rctoris@wpi.edu
+ */
+
+var Topic = require('../core/Topic');
+var Message = require('../core/Message');
+var EventEmitter2 = require('eventemitter2').EventEmitter2;
+
+/**
+ * An actionlib action listener
+ *
+ * Emits the following events:
+ *  * 'status' - the status messages received from the action server
+ *  * 'feedback' -  the feedback messages received from the action server
+ *  * 'result' - the result returned from the action server
+ *
+ *  @constructor
+ *  @param options - object with following keys:
+ *   * ros - the ROSLIB.Ros connection handle
+ *   * serverName - the action server name, like /fibonacci
+ *   * actionName - the action message name, like 'actionlib_tutorials/FibonacciAction'
+ */
+function ActionListener(options) {
+  var that = this;
+  options = options || {};
+  this.ros = options.ros;
+  this.serverName = options.serverName;
+  this.actionName = options.actionName;
+  this.timeout = options.timeout;
+  this.omitFeedback = options.omitFeedback;
+  this.omitStatus = options.omitStatus;
+  this.omitResult = options.omitResult;
+
+
+  // create the topics associated with actionlib
+  var goalListener = new Topic({
+    ros : this.ros,
+    name : this.serverName + '/goal',
+    messageType : this.actionName + 'Goal'
+  });
+
+  var feedbackListener = new Topic({
+    ros : this.ros,
+    name : this.serverName + '/feedback',
+    messageType : this.actionName + 'Feedback'
+  });
+
+  var statusListener = new Topic({
+    ros : this.ros,
+    name : this.serverName + '/status',
+    messageType : 'actionlib_msgs/GoalStatusArray'
+  });
+
+  var resultListener = new Topic({
+    ros : this.ros,
+    name : this.serverName + '/result',
+    messageType : this.actionName + 'Result'
+  });
+
+  goalListener.subscribe(function(goalMessage) {
+      that.emit('goal', goalMessage);
+  });
+
+  statusListener.subscribe(function(statusMessage) {
+      statusMessage.status_list.forEach(function(status) {
+          that.emit('status', status);
+      });
+  });
+
+  feedbackListener.subscribe(function(feedbackMessage) {
+      that.emit('status', feedbackMessage.status);
+      that.emit('feedback', feedbackMessage.feedback);
+  });
+
+  // subscribe to the result topic
+  resultListener.subscribe(function(resultMessage) {
+      that.emit('status', resultMessage.status);
+      that.emit('result', resultMessage.result);
+  });
+
+}
+
+ActionListener.prototype.__proto__ = EventEmitter2.prototype;
+
+module.exports = ActionListener;

--- a/src/actionlib/index.js
+++ b/src/actionlib/index.js
@@ -3,6 +3,7 @@ var mixin = require('../mixin');
 
 var action = module.exports = {
     ActionClient: require('./ActionClient'),
+    ActionListener: require('./ActionListener'),
     Goal: require('./Goal'),
     SimpleActionServer: require('./SimpleActionServer')
 };


### PR DESCRIPTION
I had the need to listen for arbitrary goal related messages, not just for goals created in my JS client. I wish to monitor goals and display feedback and status for goals created by another client.

As such I built this action listener (based on the existing action client) that let me subscribe to the topics directly rather than filtering based on the goals that I'd created.

I wasn't sure if there is apetite for this feature, so thought I'd submit the pull request to seek interest.