### PR TITLE
Upgraded EventEmitter2 and removed shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "main": "./src/RosLibNode.js",
   "browser": {
     "./src/RosLibNode.js": "./src/RosLib.js",
-    "eventemitter2": "./src/util/shim/EventEmitter2.js",
     "canvas": "./src/util/shim/canvas.js",
     "ws": "./src/util/shim/WebSocket.js",
     "xmldom": "./src/util/shim/xmldom.js",
@@ -34,7 +33,7 @@
     "time-grunt": "^1.0.0"
   },
   "dependencies": {
-    "eventemitter2": "^0.4.13",
+    "eventemitter2": "^1.0.0",
     "object-assign": "^4.0.1",
     "pngparse": "^2.0.1",
     "ws": "^0.8.0",

--- a/src/util/shim/EventEmitter2.js
+++ b/src/util/shim/EventEmitter2.js
@@ -1,3 +1,0 @@
-module.exports = {
-	EventEmitter2: global.EventEmitter2
-};


### PR DESCRIPTION
I upgraded the EventEmitter2 version in package.json and removed the shim. This allows roslibjs to be used in webpack projects.
