### PR TITLE
Include build directory in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 test
-build
 examples
 Gruntfile.js
 .gitignore


### PR DESCRIPTION
The package is documented (https://www.npmjs.com/package/roslib) as including roslib.js and roslib.min.js from
the build directory, but they're currently excluded. This will also make
it easier for people who want to use roslib.js without using RequireJS
or another loader.