### PR TITLE
Fix getTopics bug

### DIFF
--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -159,7 +159,7 @@ Ros.prototype.getTopics = function(callback, failedCallback) {
     );
   }else{
     topicsClient.callService(request, function(result) {
-      callback(result.topics);
+      callback(result);
     });
   }
 };


### PR DESCRIPTION
If a user did not pass in a failedCallback into getTopics(), it would only return the "topics" array from the result, rather than the full result that included both the "topics" and the "types" array.