### PR TITLE
Updating the licence so SPDX stops complaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://www.robotwebtools.org",
   "description": "The standard ROS Javascript Library",
   "version": "0.19.0-SNAPSHOT",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "main": "./src/RosLibNode.js",
   "browser": {
     "./src/RosLibNode.js": "./src/RosLib.js",


### PR DESCRIPTION
License name updated to match the LICENSE file. This is in reference to this change in NPM https://github.com/npm/npm/issues/8918