### PR TITLE
Add Release Todo document

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,23 +4,23 @@ Robot Web Tools Module Release TODOs
 This document describes TODOs and checklists in order to release
 Robot Web Tool javascript modules([roslibjs](https://github.com/RobotWebTools/roslibjs), [ros2djs](https://github.com/RobotWebTools/ros2djs), [ros3djs](https://github.com/RobotWebTools/ros3djs)).
 
-#### Make sure that the releasing module is compatible with other RWT modules.
+### Make sure that the releasing module is compatible with other RWT modules.
 
 use travis to check the compatibility?
 
-#### Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
+### Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
 
 ```
 github-changes -o RobotWebTools -r roslibjs --only-pulls --use-commit-body -a -b develop
 ```
 
-#### Bump a new version
+### Bump a new version
 
 * Remove a SNAPSHOT postfix from package.json and bowers.json
 * Mark *upcoming* in CHAGELOG.md as the new release version
 * Tag the version
 
-#### Release
+### Release
 
 **NPM**
 
@@ -34,17 +34,17 @@ Can it be automated too?
 
 TODO(@jihoonl) Fill it after release
 
-#### Update jsdocs in Robot Web Tools website
+### Update jsdocs in Robot Web Tools website
 
 [Here](https://github.com/RobotWebTools/robotwebtools.github.io/tree/master/jsdoc).
 Check if docs can be hosted directly from its own repository.
 
-#### Sync `develop` branch with `master`
+### Sync `develop` branch with `master`
 
 `Master` branch should represent the latest release. 
 * Create a PR against `master` from `develop`
 * Do *Rebase and merge* to have the same history as `develop` branch
 
-#### Prepare `develop` branch for a new version
+### Prepare `develop` branch for a new version
 
 Bump a version in package.json and bowers.json and add `-SNAPSHOT` postfix.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,23 +4,23 @@ Robot Web Tools Module Release TODOs
 This document describes TODOs and checklists in order to release
 Robot Web Tool javascript modules([roslibjs](https://github.com/RobotWebTools/roslibjs), [ros2djs](https://github.com/RobotWebTools/ros2djs), [ros3djs](https://github.com/RobotWebTools/ros3djs)).
 
-### Make sure that the releasing module is compatible with other RWT modules.
+### 0. Make sure that the releasing module is compatible with other RWT modules.
 
 use travis to check the compatibility?
 
-### Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
+### 1. Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
 
 ```
 github-changes -o RobotWebTools -r roslibjs --only-pulls --use-commit-body -a -b develop
 ```
 
-### Bump a new version
+### 2. Bump a new version
 
 * Remove a SNAPSHOT postfix from package.json and bowers.json
 * Mark *upcoming* in CHAGELOG.md as the new release version
 * Tag the version
 
-### Release
+### 3. Release modules
 
 **NPM**
 
@@ -34,17 +34,17 @@ Can it be automated too?
 
 TODO(@jihoonl) Fill it after release
 
-### Update jsdocs in Robot Web Tools website
+### 4. Update jsdocs in Robot Web Tools website
 
 [Here](https://github.com/RobotWebTools/robotwebtools.github.io/tree/master/jsdoc).
 Check if docs can be hosted directly from its own repository.
 
-### Sync `develop` branch with `master`
+### 5. Sync `develop` branch with `master`
 
 `Master` branch should represent the latest release. 
 * Create a PR against `master` from `develop`
 * Do *Rebase and merge* to have the same history as `develop` branch
 
-### Prepare `develop` branch for a new version
+### 6. Prepare `develop` branch for a new version
 
 Bump a version in package.json and bowers.json and add `-SNAPSHOT` postfix.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,23 +4,23 @@ Robot Web Tools Module Release TODOs
 This document describes TODOs and checklists in order to release
 Robot Web Tool javascript modules([roslibjs](https://github.com/RobotWebTools/roslibjs), [ros2djs](https://github.com/RobotWebTools/ros2djs), [ros3djs](https://github.com/RobotWebTools/ros3djs)).
 
-0. Make sure that the releasing module is compatible with other RWT modules.
+#### Make sure that the releasing module is compatible with other RWT modules.
 
 use travis to check the compatibility?
 
-1. Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
+#### Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
 
 ```
 github-changes -o RobotWebTools -r roslibjs --only-pulls --use-commit-body -a -b develop
 ```
 
-2. Bump a new version
+#### Bump a new version
 
 * Remove a SNAPSHOT postfix from package.json and bowers.json
 * Mark *upcoming* in CHAGELOG.md as the new release version
 * Tag the version
 
-3. Release
+#### Release
 
 **NPM**
 
@@ -34,17 +34,17 @@ Can it be automated too?
 
 TODO(@jihoonl) Fill it after release
 
-4. Update jsdocs in Robot Web Tools website
+#### Update jsdocs in Robot Web Tools website
 
 [Here](https://github.com/RobotWebTools/robotwebtools.github.io/tree/master/jsdoc).
 Check if docs can be hosted directly from its own repository.
 
-5. Sync `develop` branch with `master`
+#### Sync `develop` branch with `master`
 
 `Master` branch should represent the latest release. 
 * Create a PR against `master` from `develop`
 * Do *Rebase and merge* to have the same history as `develop` branch
 
-6. Prepare `develop` branch for a new version
+#### Prepare `develop` branch for a new version
 
 Bump a version in package.json and bowers.json and add `-SNAPSHOT` postfix.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,50 @@
+Robot Web Tools Module Release TODOs
+====================================
+
+This document describes TODOs and checklists in order to release
+Robot Web Tool javascript modules([roslibjs](https://github.com/RobotWebTools/roslibjs), [ros2djs](https://github.com/RobotWebTools/ros2djs), [ros3djs](https://github.com/RobotWebTools/ros3djs)).
+
+0. Make sure that the releasing module is compatible with other RWT modules.
+
+use travis to check the compatibility?
+
+1. Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
+
+```
+github-changes -o RobotWebTools -r roslibjs --only-pulls --use-commit-body -a -b develop
+```
+
+2. Bump a new version
+
+* Remove a SNAPSHOT postfix from package.json and bowers.json
+* Mark *upcoming* in CHAGELOG.md as the new release version
+* Tag the version
+
+3. Release
+
+**NPM**
+
+Keep all modules under @robot-web-tools scope? or in global scope? What are pros and cons?
+
+**Bowers**
+
+Can it be automated too?
+
+**CDN**
+
+TODO(@jihoonl) Fill it after release
+
+4. Update jsdocs in Robot Web Tools website
+
+[Here](https://github.com/RobotWebTools/robotwebtools.github.io/tree/master/jsdoc).
+Check if docs can be hosted directly from its own repository.
+
+5. Sync `develop` branch with `master`
+
+`Master` branch should represent the latest release. 
+* Create a PR against `master` from `develop`
+* Do *Rebase and merge* to have the same history as `develop` branch
+
+6. Prepare `develop` branch for a new version
+
+Bump a version in package.json and bowers.json and add `-SNAPSHOT` postfix.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,6 @@ Robot Web Tool javascript modules([roslibjs](https://github.com/RobotWebTools/ro
 
 ### 0. Make sure that the releasing module is compatible with other RWT modules.
 
-use travis to check the compatibility?
-
 ### 1. Generate CHANGELOG using [github-changes](https://github.com/lalitkapoor/github-changes). 
 
 ```
@@ -28,7 +26,7 @@ Keep all modules under @robot-web-tools scope? or in global scope? What are pros
 
 **CDN**
 
-TODO(@jihoonl) Fill it after release
+Talk to @rctoris
 
 ### 4. Update jsdocs in Robot Web Tools website
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,10 +26,6 @@ github-changes -o RobotWebTools -r roslibjs --only-pulls --use-commit-body -a -b
 
 Keep all modules under @robot-web-tools scope? or in global scope? What are pros and cons?
 
-**Bowers**
-
-Can it be automated too?
-
 **CDN**
 
 TODO(@jihoonl) Fill it after release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ github-changes -o RobotWebTools -r roslibjs --only-pulls --use-commit-body -a -b
 
 ### 2. Bump a new version
 
-* Remove a SNAPSHOT postfix from package.json and bowers.json
+* Version bump in package.json, bower.json, and in the mail file. e.g) [RosLib.js](src/RosLib.js)
 * Mark *upcoming* in CHAGELOG.md as the new release version
 * Tag the version
 


### PR DESCRIPTION
Hello @RobotWebTools/maintainers,

@all, I roughly wrote down todos to prepare a new version release with some discussion points. Please take a look and leave a comment. Correcting my english is also very welcome. And does anyone experience with bowers?

@nuclearsandwich I think some steps are automatable. e.g) (update changelog, version bump and tagging), (Releasing in npm and bowers).

@sevenbitbyte having a scoped package approach seems a good idea to manage multiple modules under the same namespace. But, I would like to continue to keep roslibjs in global scope because it has  been served in global scope for ages already. Do you know any good way of managing a module for both global and org scoped?

@jihoonl will fill out CDN part after releasing npm module.

