### PR TITLE
Add the type of service when executing 'call_service'

### DIFF
--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -59,6 +59,7 @@ Service.prototype.callService = function(request, callback, failedCallback) {
     op : 'call_service',
     id : serviceCallId,
     service : this.name,
+    type: this.serviceType,
     args : request
   };
   this.ros.callOnConnection(call);


### PR DESCRIPTION
We want to reuse the roslibjs as the front-end JavaScript library by
leveraging the ros2-web-bridge in ROS2. But the current roslibjs doesn't
transmit the service type when calling a service, which is a necessary
element when sending the request in ROS2.

This patch adds this information to make it compatible with ROS2.