### PR TITLE
update shim files to use window instead of global

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     },
     jshint: {
       options: {
-        jshintrc: '.jshintrc'
+        jshintrc: true
       },
       files: [
         './Gruntfile.js',

--- a/src/util/shim/.jshintrc
+++ b/src/util/shim/.jshintrc
@@ -1,0 +1,24 @@
+{
+  "globals": {
+    "Blob": true,
+    "FileReader": true
+  },
+  "browser": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "latedef": false,
+  "newcap": true,
+  "noarg": true,
+  "sub": true,
+  "undef": true,
+  "boss": false,
+  "eqnull": false,
+  "node": true,
+  "devel": true,
+  "strict": false,
+  "trailing": true,
+  "quotmark": "single",
+  "proto": true,
+  "laxbreak": true
+}

--- a/src/util/shim/WebSocket.js
+++ b/src/util/shim/WebSocket.js
@@ -1,1 +1,1 @@
-module.exports = global.WebSocket;
+module.exports = window.WebSocket;

--- a/src/util/shim/decompressPng.js
+++ b/src/util/shim/decompressPng.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var Canvas = require('canvas');
-var Image = Canvas.Image || global.Image;
+var Image = Canvas.Image || window.Image;
 
 /**
  * If a message was compressed as a PNG image (a compression hack since

--- a/src/util/shim/xmldom.js
+++ b/src/util/shim/xmldom.js
@@ -1,3 +1,3 @@
-exports.DOMImplementation = global.DOMImplementation;
-exports.XMLSerializer = global.XMLSerializer;
-exports.DOMParser = global.DOMParser;
+exports.DOMImplementation = window.DOMImplementation;
+exports.XMLSerializer = window.XMLSerializer;
+exports.DOMParser = window.DOMParser;


### PR DESCRIPTION
The files in /shim is only used in browsers (remapped in the browser
field of package.json) when using build tools. Browsers do not have the
global propery which is a node thing. Browsers instead have the global
namespace window.

This commit solve my problem of importing roslib in my application and
building with webpack 4 without having webpack shim global = window.

Note: updated Gruntfile.js to have jshint read the config file from the
closes directory/parent directory and added a new .jshintrc to /shim to
lint the files there with a browser environment in mind.