### PR TITLE
Prevent multiple web socket connections being opened.

### DIFF
--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -69,8 +69,10 @@ Ros.prototype.connect = function(url) {
     this.socket.on('error', this.socket.onerror);
   } else if (this.transportLibrary.constructor.name === 'RTCPeerConnection') {
     this.socket = assign(this.transportLibrary.createDataChannel(url, this.transportOptions), socketAdapter(this));
-  }else {
-    this.socket = assign(new WebSocket(url), socketAdapter(this));
+  } else {
+    if (!this.socket || this.socket.readyState == WebSocket.CLOSED) {
+      this.socket = assign(new WebSocket(url), socketAdapter(this));
+    }
   }
 
 };


### PR DESCRIPTION
When `connect(...)` was called on an already connected `Ros` instance, a new web socket connection was initiated and the previous one not closed. This patch makes sure that we only create a new connection if there is none yet or the current one has been closed.

Note that this is only done for `WebSocket` connection here. Should ideally be implemented also for the other transports.