### PR TITLE
Don't allow unsupported compression types

### DIFF
--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -43,6 +43,7 @@ function Topic(options) {
     this.compression !== 'cbor' && this.compression !== 'none') {
     this.emit('warning', this.compression +
       ' compression is not supported. No compression will be used.');
+    this.compression = 'none';
   }
 
   // Check if throttle rate is negative


### PR DESCRIPTION
Fix forward compatibility issues by not requesting compression from the server that we can't actually decompress.