### PR TITLE
Fix CBOR native array decoding offset

### DIFF
--- a/src/util/cborTypedArrayTags.js
+++ b/src/util/cborTypedArrayTags.js
@@ -18,9 +18,10 @@ function decodeUint64LE(bytes) {
   warnPrecision();
 
   var byteLen = bytes.byteLength;
+  var offset = bytes.byteOffset;
   var arrLen = byteLen / 8;
 
-  var buffer = bytes.buffer.slice(-byteLen);
+  var buffer = bytes.buffer.slice(offset, offset + byteLen);
   var uint32View = new Uint32Array(buffer);
 
   var arr = new Array(arrLen);
@@ -42,9 +43,10 @@ function decodeInt64LE(bytes) {
   warnPrecision();
 
   var byteLen = bytes.byteLength;
+  var offset = bytes.byteOffset;
   var arrLen = byteLen / 8;
 
-  var buffer = bytes.buffer.slice(-byteLen);
+  var buffer = bytes.buffer.slice(offset, offset + byteLen);
   var uint32View = new Uint32Array(buffer);
   var int32View = new Int32Array(buffer);
 
@@ -66,7 +68,8 @@ function decodeInt64LE(bytes) {
 */
 function decodeNativeArray(bytes, ArrayType) {
   var byteLen = bytes.byteLength;
-  var buffer = bytes.buffer.slice(-byteLen);
+  var offset = bytes.byteOffset;
+  var buffer = bytes.buffer.slice(offset, offset + byteLen);
   return new ArrayType(buffer);
 }
 

--- a/test/cbor.test.js
+++ b/test/cbor.test.js
@@ -112,4 +112,18 @@ describe('CBOR Typed Array Tagger', function() {
     expect(msg[1]).to.be.closeTo(-2.2, 1e-5);
     expect(msg[2]).to.be.closeTo(3.3, 1e-5);
   });
+
+  it('should be able to unpack two typed arrays', function() {
+    var data = hexToBuffer('82d8484308fe05d84d460100feff0300');
+    var msg = CBOR.decode(data, cborTypedArrayTagger);
+
+    expect(msg).to.be.a('Array');
+    expect(msg).to.have.lengthOf(2);
+    expect(msg[0][0]).to.equal(8);
+    expect(msg[0][1]).to.equal(-2);
+    expect(msg[0][2]).to.equal(5);
+    expect(msg[1][0]).to.equal(1);
+    expect(msg[1][1]).to.equal(-2);
+    expect(msg[1][2]).to.equal(3);
+  });
 });


### PR DESCRIPTION
Typed array decoding was broken when the typed array was not the last item in the encoded message.  Added a failing test then fixed it.