### PR TITLE
WIP: Remove EventEmitter from roslib.js bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./src/RosLibNode.js",
   "browser": {
     "./src/RosLibNode.js": "./src/RosLib.js",
+    "eventemitter2": "./src/util/shim/EventEmitter2.js",
     "canvas": "./src/util/shim/canvas.js",
     "ws": "./src/util/shim/WebSocket.js",
     "@xmldom/xmldom": "./src/util/shim/@xmldom/xmldom.js",

--- a/src/util/shim/EventEmitter2.js
+++ b/src/util/shim/EventEmitter2.js
@@ -1,0 +1,3 @@
+module.exports = {
+	EventEmitter2: window.EventEmitter2
+};


### PR DESCRIPTION
I'm not sure why, but EventEmitter is included within roslib.js. It
should be a dependency according to all the readmes. This change excludes it from the bundle.

| name | roslib.js | roslib.min.js |
|------|-----------|---------------|
| old  | 131K      | 53K           |
| new  | 104K      | 42K           |

Bundle size analysis here:
https://roslibjs-bundle-size-example.netlify.com