### PR TITLE
Support the case material's name is empty string

### DIFF
--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -71,7 +71,7 @@ function UrdfModel(options) {
         for( var j=0; j<link.visuals.length; j++ )
         {
           var mat = link.visuals[j].material; 
-          if ( mat !== null ) {
+          if ( mat !== null && mat.name ) {
             if (this.materials[mat.name] !== void 0) {
               link.visuals[j].material = this.materials[mat.name];
             } else {


### PR DESCRIPTION
Some robot's definition has empty string for material's name. And the empty string caused `this.materials` mess up. 
This fix the problem. 