### PR TITLE
Update socket.io to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "xmldom": "^0.1.19",
     "cbor-js": "^0.1.0",
     "webworkify": "^1.5.0",
-    "socket.io": "2.2.0"
+    "socket.io": "^3.0.3"
   },
   "directories": {
     "example": "examples",


### PR DESCRIPTION
I have a test in my JS app that won't run because of an issue with old `socket.io`/`engine.io`. Moving to `socket.io` `3.x` solved the issue for me.

And never a bad idea to keep up-to-date with your dependencies