### PR TITLE
(actions) dont't run pull_request on develop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches-ignore:
+      - develop
 
 jobs:
   ci:


### PR DESCRIPTION
Branches need to be up-to-date when merging to `develop`, so `pull_request` and `push` runs are the same.

https://github.com/RobotWebTools/roslibjs/pull/426 Shows that PRs to other branches than `develop` do run the `pull_request`.

The `pull_request` runs on this PR are actually from https://github.com/RobotWebTools/roslibjs/pull/426.