### PR TITLE
change dependbot schedule to montly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Until https://github.com/dependabot/dependabot-core/issues/1190 gets resolved. It seems to create extreme noise at the moment.

@MatthijsBurgh  how do you think? Or I wonder if we can automatically merge these PRs. It seems too noisy as well as makes clicking burden.