### PR TITLE
Auto Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,3 +23,8 @@ jobs:
         run: docker build --build-arg ROS_DISTRO="${{ matrix.ros_distro }}" --build-arg NODE_VERSION="${{ matrix.node_version }}" -t roslibjsdocker .
       - name: Tests
         run: docker run -v $(pwd):/root/roslibjs --rm roslibjsdocker bash -i -c 'bash /root/roslibjs/test/build.bash'
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ (github.event_name == 'push' && github.ref == 'develop' }}
+        with:
+          commit_message: Update Build
+          file_pattern: 'build/*.js'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Tests
         run: docker run -v $(pwd):/root/roslibjs --rm roslibjsdocker bash -i -c 'bash /root/roslibjs/test/build.bash'
       - uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{ (github.event_name == 'push' && github.ref == 'develop' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'develop' && matrix.ros_distro == 'noetic' }}
         with:
           commit_message: Update Build
           file_pattern: 'build/*.js'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   ci:
     name: ${{ matrix.ros_distro }}
+    if: ${{ github.actor != 'RWT-bot' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
         node_version: [14]
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.RWT_BOT_PAT }}
       - name: Docker pull
         run: docker pull ros:${{ matrix.ros_distro }}-ros-core
       - name: Docker build

--- a/test/build.bash
+++ b/test/build.bash
@@ -32,13 +32,3 @@ echo -e "\e[1m\e[35mnpm run test-examples\e[0m"
 npm run test-examples
 echo -e "\e[1m\e[35mnpm run test-workersocket\e[0m"
 npm run test-workersocket
-
-echo -e "\e[1m\e[35mChecking build folder is up-to-date with library\e[0m"
-changed_build_files=$(git -C "$(git rev-parse --show-toplevel)" diff --name-only HEAD -- build)
-if [ -n "$changed_build_files" ]
-then
-    echo -e "\e[1m\e[31mBuild folder is out-of-sync with library. Build library, npm run build, and (ammend) commit\e[0m"
-    exit 1
-else
-    echo -e "\e[1m\e[32mBuild folder is up-to-date with library\e[0m"
-fi


### PR DESCRIPTION
Instead of requiring the build to be up-to-date, GH actions will push the build folder when the CI procedure has resulted in a diff.

To test it, I added some commits to push on this feature branch. The commit done by GH actions: https://github.com/RobotWebTools/roslibjs/pull/446/commits/5112758bd684e31c5bdefaf562e52ce0cd1d7575

GH actions run: https://github.com/RobotWebTools/roslibjs/runs/2758087742?check_suite_focus=true

I dropped these commits again and forced pushed. I can't guarantee this will work with the branch protection on `develop`. But merge this PR is the only way to find out. There is no other way to test this.

Once approved, I will apply this to ros3djs and ros3djs too.