### PR TITLE
Prevent race condition in TFClient

### DIFF
--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -52,6 +52,7 @@ function TFClient(options) {
   this.frameInfos = {};
   this.republisherUpdateRequested = false;
   this._subscribeCB = null;
+  this._isDisposed = false;
 
   // Create an Action client
   this.actionClient = new ActionClient({
@@ -144,6 +145,12 @@ TFClient.prototype.updateGoal = function() {
  * @param response the service response containing the topic name
  */
 TFClient.prototype.processResponse = function(response) {
+  // Do not setup a topic subscription if already disposed. Prevents a race condition where
+  // The dispose() function is called before the service call receives a response.
+  if (this._isDisposed) {
+    return;
+  }
+
   // if we subscribed to a topic before, unsubscribe so
   // the republisher stops publishing it
   if (this.currentTopic) {
@@ -216,6 +223,7 @@ TFClient.prototype.unsubscribe = function(frameID, callback) {
  * Unsubscribe and unadvertise all topics associated with this TFClient.
  */
 TFClient.prototype.dispose = function() {
+  this._isDisposed = true;
   this.actionClient.dispose();
   if (this.currentTopic) {
     this.currentTopic.unsubscribe(this._subscribeCB);

--- a/test/tfclient.test.js
+++ b/test/tfclient.test.js
@@ -1,0 +1,30 @@
+var expect = require('chai').expect;
+var ROSLIB = require('..');
+
+describe('TFClient', function() {
+
+  describe('dispose', function() {
+    
+    it('should not subscribe to republished topic if already disposed', function() {
+      // This test makes sure we do not subscribe to the republished topic if the 
+      // tf client has already been disposed when we get the response (from the setup request)
+      // from the server.
+
+      var dummyROS = {
+        idCounter: 0,
+        on: () => {},
+        off: () => {},
+        callOnConnection: () => {}
+      }
+
+      var tfclient = new ROSLIB.TFClient({ros: dummyROS});
+      tfclient.dispose();
+
+      // Simulated a response from the server after the client is already disposed
+      tfclient.processResponse({topic_name: "/repub_1"});
+
+      expect(tfclient.currentTopic).to.be.false;
+    });
+  });
+
+});


### PR DESCRIPTION
**Public API Changes**
None

**Description**
If a TFClient is disposed while a service call to update the goal is ongoing it will subscribe to the republished topic even if already disposed. To prevent this we mark the TFClient as disposed when it is disposed, and check for this in the service callback.


<!-- Link relevant GitHub issues -->
Fixes #488 