### PR TITLE
Add channel omission flags to ActionClient's JSDoc param tag

### DIFF
--- a/src/actionlib/ActionClient.js
+++ b/src/actionlib/ActionClient.js
@@ -22,6 +22,9 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2;
  *   * serverName - the action server name, like /fibonacci
  *   * actionName - the action message name, like 'actionlib_tutorials/FibonacciAction'
  *   * timeout - the timeout length when connecting to the action server
+ *   * omitFeedback - the boolean flag to indicate whether to omit the feedback channel or not
+ *   * omitStatus - the boolean flag to indicate whether to omit the status channel or not
+ *   * omitResult - the boolean flag to indicate whether to omit the result channel or not
  */
 function ActionClient(options) {
   var that = this;


### PR DESCRIPTION
**Public API Changes**
This PR makes the following channel omission flags for `ActionClient` explicitly visible to the user via JSDoc's `@param` tag:
- `omitFeedback`
- `omitStatus`
- `omitResult`

**Description**
This change is in line with PR #202. This PR explicitly allows the aforementioned channel omission flags to be passed in as part of the `options` parameter of the constructor function of `ActionClient`.