### PR TITLE
(examples) no need for EventEmitter CDN

### DIFF
--- a/examples/fibonacci.html
+++ b/examples/fibonacci.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<script src="https://cdn.jsdelivr.net/npm/eventemitter2@6/lib/eventemitter2.min.js"></script>
 <script src="../build/roslib.js"></script>
 
 <script>

--- a/examples/fibonacci_server.html
+++ b/examples/fibonacci_server.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<script src="https://cdn.jsdelivr.net/npm/eventemitter2@6/lib/eventemitter2.min.js"></script>
 <script src="../build/roslib.js"></script>
 
 <script>

--- a/examples/math.html
+++ b/examples/math.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<script src="https://cdn.jsdelivr.net/npm/eventemitter2@6/lib/eventemitter2.min.js"></script>
 <script src="../build/roslib.js"></script>
 
 <script>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<script src="https://cdn.jsdelivr.net/npm/eventemitter2@6/lib/eventemitter2.min.js"></script>
 <script src="../build/roslib.js"></script>
 
 <script>

--- a/examples/tf.html
+++ b/examples/tf.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<script src="https://cdn.jsdelivr.net/npm/eventemitter2@6/lib/eventemitter2.min.js"></script>
 <script src="../build/roslib.js"></script>
 
 <script>

--- a/examples/urdf.html
+++ b/examples/urdf.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<script src="https://cdn.jsdelivr.net/npm/eventemitter2@6/lib/eventemitter2.min.js"></script>
 <script src="../build/roslib.js"></script>
 
 <script>


### PR DESCRIPTION
As this is included in the build

Fixes https://github.com/RobotWebTools/roslibjs/issues/614