### PR TITLE
Ensure `fieldType` is a scalar if `arrayLen` is `-1`

### DIFF
--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -637,16 +637,11 @@ Ros.prototype.getMessageDetails = function(message, callback, failedCallback) {
   }
 };
 
-/**
- * Decode a typedef array into a dictionary like `rosmsg show foo/bar`.
- *
- * @param {Object[]} defs - Array of type_def dictionary.
- */
 Ros.prototype.decodeTypeDefs = function(defs) {
   var that = this;
 
-  // calls itself recursively to resolve type definition using hints.
   var decodeTypeDefsRec = function(theType, hints) {
+    console.debug(`🍋 decoding typedef`, theType);
     var typeDefDict = {};
     for (var i = 0; i < theType.fieldnames.length; i++) {
       var arrayLen = theType.fieldarraylen[i];
@@ -672,6 +667,7 @@ Ros.prototype.decodeTypeDefs = function(defs) {
         if (sub) {
           var subResult = decodeTypeDefsRec(sub, hints);
           if (arrayLen === -1) {
+            typeDefDict[fieldName] = subResult; // add this decoding result to dictionary
           }
           else {
             typeDefDict[fieldName] = [subResult];

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -646,8 +646,8 @@ Ros.prototype.decodeTypeDefs = function(defs) {
   var that = this;
 
   var decodeTypeDefsRec = function(theType, hints) {
-    var typeDefDict = {};
     // calls itself recursively to resolve type definition using hints.
+    var typeDefDict = {};
     for (var i = 0; i < theType.fieldnames.length; i++) {
       var arrayLen = theType.fieldarraylen[i];
       var fieldName = theType.fieldnames[i];

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -637,12 +637,17 @@ Ros.prototype.getMessageDetails = function(message, callback, failedCallback) {
   }
 };
 
+/**
+ * Decode a typedef array into a dictionary like `rosmsg show foo/bar`.
+ *
+ * @param {Object[]} defs - Array of type_def dictionary.
+ */
 Ros.prototype.decodeTypeDefs = function(defs) {
   var that = this;
 
   var decodeTypeDefsRec = function(theType, hints) {
-    console.debug(`🍋 decoding typedef`, theType);
     var typeDefDict = {};
+    // calls itself recursively to resolve type definition using hints.
     for (var i = 0; i < theType.fieldnames.length; i++) {
       var arrayLen = theType.fieldarraylen[i];
       var fieldName = theType.fieldnames[i];


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Before this change, `typeDefDict[fieldName]` was always assigned as an array, irrespective of other variables’ states. With this new update, if the `arrayLen` is equal to `-1`, the `typeDefDict[fieldName]` is assigned the non-array value `fieldType`. If `arrayLen` doesn't equal `-1`, the assignment remains an array format, `[fieldType]`.

We used this to successfully [decode ROS2 nested types](https://github.com/RobotWebTools/rosbridge_suite/pull/883).

<!-- Link relevant GitHub issues -->
#463 