### PR TITLE
Modernize import syntax to ESModules

### DIFF
--- a/Gruntfile.cjs
+++ b/Gruntfile.cjs
@@ -1,6 +1,3 @@
-
-'use strict';
-
 module.exports = function(grunt) {
 
   // Time how long tasks take. Can help when optimizing build times

--- a/Gruntfile.cjs
+++ b/Gruntfile.cjs
@@ -1,3 +1,4 @@
+
 'use strict';
 
 module.exports = function(grunt) {
@@ -18,7 +19,11 @@ module.exports = function(grunt) {
     browserify: {
       dist: {
         src: ['./tsbuild/RosLib.js'],
-        dest: './build/roslib.js'
+        dest: './build/roslib.js',
+        options: {
+          plugin: ['esmify'],
+          ignore: ['ws']
+        }
       }
     },
     uglify: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
-const globals = require('globals');
+import globals from 'globals';
 
-module.exports = [
+export default [
   {
     languageOptions: {
       'globals': {

--- a/examples/node_simple.js
+++ b/examples/node_simple.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Connecting to ROS
-var ROSLIB = require('roslib');
+import ROSLIB from 'roslib';
 
 var ros = new ROSLIB.Ros({
   url: 'ws://localhost:9090'

--- a/examples/react-example/src/component_examples/example_functions.jsx
+++ b/examples/react-example/src/component_examples/example_functions.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import ROSLIB from '../../../..'
+import * as ROSLIB from '../../../../src/RosLib.js'
 
 function SendMessage() {
   const [status, setStatus] = useState('Not connected')

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
       },
       "devDependencies": {
         "@testing-library/react": "^14.2.1",
+        "@types/node": "^20.11.19",
         "eslint": "^8.56.0",
+        "esmify": "^2.1.1",
         "grunt": "^1.0.0",
         "grunt-browserify": "^6.0.0",
         "grunt-cli": "^1.2.0",
@@ -46,6 +48,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -132,11 +147,217 @@
         "node": ">=4"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+      "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.23.6",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+      "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -227,15 +448,68 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
+      "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-simple-access": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -245,6 +519,64 @@
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+      "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -764,11 +1096,53 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1094,8 +1468,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
       "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1515,6 +1887,205 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-import-to-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import-to-require/-/babel-plugin-import-to-require-1.0.0.tgz",
+      "integrity": "sha512-dc843CwrFivjO8AVgxcHvxl0cb7J7Ed8ZGFP8+PjH3X1CnyzYtAU1WL1349m9Wc/+oqk4ETx2+cIEO2jlp3XyQ==",
+      "dev": true,
+      "dependencies": {
+        "babel-template": "^6.26.0"
+      }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "node_modules/babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babel-types/node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1865,6 +2436,38 @@
         "pako": "~1.0.5"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
@@ -1935,6 +2538,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001588",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
+      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/catharsis": {
       "version": "0.9.0",
@@ -2131,6 +2754,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "hasInstallScript": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2523,6 +3154,12 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.676",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.676.tgz",
+      "integrity": "sha512-uHt4FB8SeYdhcOsj2ix/C39S7sPSNFJpzShjxGOm1KdF4MHyGqGi389+T5cErsodsijojXilYaHIKKqJfqh7uQ==",
+      "dev": true
+    },
     "node_modules/elliptic": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -2701,6 +3338,15 @@
         "@esbuild/win32-x64": "0.19.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -2860,6 +3506,24 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/esmify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/esmify/-/esmify-2.1.1.tgz",
+      "integrity": "sha512-GyOVgjG7sNyYB5Mbo15Ll4aGrcXZzZ3LI22rbLOjCI7L/wYelzQpBHRZkZkqbPNZ/QIRilcaHqzgNCLcEsi1lQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.2.2",
+        "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+        "babel-plugin-import-to-require": "^1.0.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "^1.6.2",
+        "duplexer2": "^0.1.4",
+        "through2": "^2.0.5"
       }
     },
     "node_modules/espree": {
@@ -3333,6 +3997,15 @@
       },
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-assigned-identifiers": {
@@ -4265,6 +4938,15 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -4798,6 +5480,18 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -4815,6 +5509,18 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.1",
@@ -5018,7 +5724,6 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5033,6 +5738,15 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
@@ -5405,6 +6119,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/nopt": {
@@ -6553,6 +7273,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
@@ -7131,6 +7860,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7348,9 +8086,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -7359,6 +8095,36 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -7861,6 +8627,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "version": "1.4.1",
   "license": "BSD-2-Clause",
   "main": "./src/RosLib.js",
+  "type": "module",
   "browser": {
     "canvas": "./src/util/shim/canvas.js",
-    "ws": "./src/util/shim/WebSocket.js",
-    "@xmldom/xmldom": "./src/util/shim/@xmldom/xmldom.js",
     "./src/util/decompressPng.js": "./src/util/shim/decompressPng.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.2.1",
+    "@types/node": "^20.11.19",
     "eslint": "^8.56.0",
+    "esmify": "^2.1.1",
     "grunt": "^1.0.0",
     "grunt-browserify": "^6.0.0",
     "grunt-cli": "^1.2.0",

--- a/src/RosLib.js
+++ b/src/RosLib.js
@@ -19,6 +19,7 @@ import * as Urdf from './urdf/index.js';
 
 // Add to global namespace for in-browser support (i.e. CDN)
 global.ROSLIB = {
+  REVISION,
   ...Core,
   ...ActionLib,
   ...Math,

--- a/src/RosLib.js
+++ b/src/RosLib.js
@@ -3,25 +3,25 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-/**
- * If you use roslib in a browser, all the classes will be exported to a global variable called ROSLIB.
- *
- * If you use nodejs, this is the variable you get when you require('roslib').
- */
-var ROSLIB = {
-  /**
-   * @default
-   * @description Library version
-   */
-  REVISION: '1.4.1',
-  ...require('./core'),
-  ...require('./actionlib'),
-  ...require('./math'),
-  ...require('./tf'),
-  ...require('./urdf')
-};
+/** @description Library version */
+export const REVISION = '1.4.1';
+export * from './core/index.js';
+export * from './actionlib/index.js';
+export * from './math/index.js';
+export * from './tf/index.js';
+export * from './urdf/index.js';
 
-module.exports = ROSLIB;
+import * as Core from './core/index.js';
+import * as ActionLib from './actionlib/index.js';
+import * as Math from './math/index.js';
+import * as Tf from './tf/index.js';
+import * as Urdf from './urdf/index.js';
 
 // Add to global namespace for in-browser support (i.e. CDN)
-global.ROSLIB = ROSLIB;
+global.ROSLIB = {
+  ...Core,
+  ...ActionLib,
+  ...Math,
+  ...Tf,
+  ...Urdf
+};

--- a/src/actionlib/ActionClient.js
+++ b/src/actionlib/ActionClient.js
@@ -3,10 +3,10 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var Topic = require('../core/Topic');
-var Message = require('../core/Message');
-var EventEmitter = require('eventemitter3').EventEmitter;
-var Ros = require('../core/Ros');
+import Topic from '../core/Topic.js';
+import Message from '../core/Message.js';
+import Ros from '../core/Ros.js';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * An actionlib action client.
@@ -18,7 +18,7 @@ var Ros = require('../core/Ros');
  *  * 'result' - The result returned from the action server.
  *
  */
-class ActionClient extends EventEmitter {
+export default class ActionClient extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -148,5 +148,3 @@ class ActionClient extends EventEmitter {
     }
   }
 }
-
-module.exports = ActionClient;

--- a/src/actionlib/ActionListener.js
+++ b/src/actionlib/ActionListener.js
@@ -4,10 +4,9 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var Topic = require('../core/Topic');
-var Message = require('../core/Message');
-var EventEmitter = require('eventemitter3').EventEmitter;
-var Ros = require('../core/Ros');
+import Topic from '../core/Topic.js';
+import Ros from '../core/Ros.js';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * An actionlib action listener.
@@ -19,7 +18,7 @@ var Ros = require('../core/Ros');
  *
 
  */
-class ActionListener extends EventEmitter {
+export default class ActionListener extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -80,5 +79,3 @@ class ActionListener extends EventEmitter {
     });
   }
 }
-
-module.exports = ActionListener;

--- a/src/actionlib/Goal.js
+++ b/src/actionlib/Goal.js
@@ -3,9 +3,9 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var Message = require('../core/Message');
-var EventEmitter = require('eventemitter3').EventEmitter;
-var ActionClient = require('./ActionClient');
+import { EventEmitter } from 'eventemitter3';
+import Message from '../core/Message.js';
+import ActionClient from './ActionClient.js';
 
 /**
  * An actionlib goal that is associated with an action server.
@@ -13,7 +13,7 @@ var ActionClient = require('./ActionClient');
  * Emits the following events:
  *  * 'timeout' - If a timeout occurred while sending a goal.
  */
-class Goal extends EventEmitter {
+export default class Goal extends EventEmitter {
   /**
    * @param {Object} options
    * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.
@@ -88,5 +88,3 @@ class Goal extends EventEmitter {
     this.actionClient.cancelTopic.publish(cancelMessage);
   }
 }
-
-module.exports = Goal;

--- a/src/actionlib/SimpleActionServer.js
+++ b/src/actionlib/SimpleActionServer.js
@@ -3,10 +3,10 @@
  * @author Laura Lindzey - lindzey@gmail.com
  */
 
-var Topic = require('../core/Topic');
-var Message = require('../core/Message');
-var EventEmitter = require('eventemitter3').EventEmitter;
-var Ros = require('../core/Ros');
+import Topic from '../core/Topic.js';
+import Message from '../core/Message.js';
+import Ros from '../core/Ros.js';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * An actionlib action server client.
@@ -15,7 +15,7 @@ var Ros = require('../core/Ros');
  *  * 'goal' - Goal sent by action client.
  *  * 'cancel' - Action client has canceled the request.
  */
-class SimpleActionServer extends EventEmitter {
+export default class SimpleActionServer extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -240,5 +240,3 @@ class SimpleActionServer extends EventEmitter {
     }
   }
 }
-
-module.exports = SimpleActionServer;

--- a/src/actionlib/index.js
+++ b/src/actionlib/index.js
@@ -1,6 +1,4 @@
-module.exports = {
-  ActionClient: require('./ActionClient'),
-  ActionListener: require('./ActionListener'),
-  Goal: require('./Goal'),
-  SimpleActionServer: require('./SimpleActionServer')
-};
+export { default as ActionClient } from './ActionClient.js';
+export { default as ActionListener } from './ActionListener.js';
+export { default as Goal } from './Goal.js';
+export { default as SimpleActionServer } from './SimpleActionServer.js';

--- a/src/core/Action.js
+++ b/src/core/Action.js
@@ -3,14 +3,14 @@
  * @author Sebastian Castro - sebastian.castro@picknik.ai
  */
 
-var EventEmitter = require('eventemitter3').EventEmitter;
-var Ros = require('../core/Ros');
+import { EventEmitter } from 'eventemitter3';
+import Ros from '../core/Ros.js';
 
 /**
  * A ROS 2 action client.
  * @template TGoal, TFeedback, TResult
  */
-class Action extends EventEmitter {
+export default class Action extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -55,17 +55,24 @@ class Action extends EventEmitter {
       return;
     }
 
-    var actionGoalId = 'send_action_goal:' + this.name + ':' + (++this.ros.idCounter);
+    var actionGoalId =
+      'send_action_goal:' + this.name + ':' + ++this.ros.idCounter;
 
     if (resultCallback || failedCallback) {
-      this.ros.on(actionGoalId, function(message) {
+      this.ros.on(actionGoalId, function (message) {
         if (message.result !== undefined && message.result === false) {
           if (typeof failedCallback === 'function') {
             failedCallback(message.values);
           }
-        } else if (message.op === 'action_feedback' && typeof feedbackCallback === 'function') {
+        } else if (
+          message.op === 'action_feedback' &&
+          typeof feedbackCallback === 'function'
+        ) {
           feedbackCallback(message.values);
-        } else if (message.op === 'action_result' && typeof resultCallback === 'function') {
+        } else if (
+          message.op === 'action_result' &&
+          typeof resultCallback === 'function'
+        ) {
           resultCallback(message.values);
         }
       });
@@ -86,14 +93,14 @@ class Action extends EventEmitter {
 
   /**
    * Cancels an action goal.
-   * 
+   *
    * @param {string} id - The ID of the action goal to cancel.
    */
   cancelGoal(id) {
     var call = {
       op: 'cancel_action_goal',
       id: id,
-      action: this.name,
+      action: this.name
     };
     this.ros.callOnConnection(call);
   }
@@ -148,26 +155,28 @@ class Action extends EventEmitter {
    * Helper function that executes an action by calling the provided
    * action callback with the auto-generated ID as a user-accessible input.
    * Should not be called manually.
-   * 
+   *
    * @param {Object} rosbridgeRequest - The rosbridge request containing the action goal to send and its ID.
    * @param {string} rosbridgeRequest.id - The ID of the action goal.
    * @param {TGoal} rosbridgeRequest.args - The arguments of the action goal.
    */
   _executeAction(rosbridgeRequest) {
-    var id  = rosbridgeRequest.id;
+    var id = rosbridgeRequest.id;
 
     // If a cancellation callback exists, call it when a cancellation event is emitted.
     if (typeof id === 'string') {
       this.ros.on(id, (message) => {
-        if (message.op === 'cancel_action_goal' && typeof this._cancelCallback === 'function') {
+        if (
+          message.op === 'cancel_action_goal' &&
+          typeof this._cancelCallback === 'function'
+        ) {
           this._cancelCallback(id);
         }
       });
     }
 
     // Call the action goal execution function provided.
-    if (typeof this._actionCallback === 'function')
-    {
+    if (typeof this._actionCallback === 'function') {
       this._actionCallback(rosbridgeRequest.args, id);
     }
   }
@@ -183,7 +192,7 @@ class Action extends EventEmitter {
       op: 'action_feedback',
       id: id,
       action: this.name,
-      values: feedback,
+      values: feedback
     };
     this.ros.callOnConnection(call);
   }
@@ -200,7 +209,7 @@ class Action extends EventEmitter {
       id: id,
       action: this.name,
       values: result,
-      result: true,
+      result: true
     };
     this.ros.callOnConnection(call);
   }
@@ -215,10 +224,8 @@ class Action extends EventEmitter {
       op: 'action_result',
       id: id,
       action: this.name,
-      result: false,
+      result: false
     };
     this.ros.callOnConnection(call);
   }
 }
-
-module.exports = Action;

--- a/src/core/Message.js
+++ b/src/core/Message.js
@@ -3,7 +3,7 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-var assign = require('object-assign');
+import assign from 'object-assign';
 
 /**
  * Message objects are used for publishing and subscribing to and from topics.
@@ -11,7 +11,7 @@ var assign = require('object-assign');
  * @constructor
  * @template T
 */
-class Message {
+export default class Message {
   /**
    * @param {T} [values={}] - An object matching the fields defined in the .msg definition file.
    */
@@ -19,5 +19,3 @@ class Message {
     assign(this, values || {});
   }
 }
-
-module.exports = Message;

--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -3,14 +3,14 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-var Service = require('./Service');
-var ServiceRequest = require('./ServiceRequest');
-var Ros = require('../core/Ros');
+import Service from './Service.js';
+import ServiceRequest from './ServiceRequest.js';
+import Ros from '../core/Ros.js';
 
 /**
  * A ROS parameter.
  */
-class Param {
+export default class Param {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -103,5 +103,3 @@ class Param {
     paramClient.callService(request, callback, failedCallback);
   }
 }
-
-module.exports = Param;

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -3,19 +3,20 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-var WebSocket = require('ws');
-var socketAdapter = require('./SocketAdapter.js');
+import socketAdapter from './SocketAdapter.js';
 
-var Service = require('./Service');
-var ServiceRequest = require('./ServiceRequest');
-var ServiceResponse = require('./ServiceResponse');
+import Service from './Service.js';
+import ServiceRequest from './ServiceRequest.js';
+import ServiceResponse from './ServiceResponse.js';
 
-var assign = require('object-assign');
-const Topic = require('./Topic');
-const Param = require('./Param');
-const { TFClient } = require('../tf');
-const { ActionClient, SimpleActionServer } = require('../actionlib');
-var EventEmitter = require('eventemitter3').EventEmitter;
+import assign from 'object-assign';
+import Topic from './Topic.js';
+import Param from './Param.js';
+import TFClient from '../tf/TFClient.js';
+import ActionClient from '../actionlib/ActionClient.js';
+import SimpleActionServer from '../actionlib/SimpleActionServer.js';
+import { EventEmitter } from 'eventemitter3';
+import { WebSocket } from 'ws';
 
 /**
  * Manages connection to the server and all interactions with ROS.
@@ -27,7 +28,7 @@ var EventEmitter = require('eventemitter3').EventEmitter;
  *  * &#60;topicName&#62; - A message came from rosbridge with the given topic name.
  *  * &#60;serviceID&#62; - A service response came from rosbridge with the given ID.
  */
-class Ros extends EventEmitter {
+export default class Ros extends EventEmitter {
   /**
    * @param {Object} [options]
    * @param {string} [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.
@@ -73,7 +74,8 @@ class Ros extends EventEmitter {
       );
     } else if (this.transportLibrary === 'websocket') {
       if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
-        var sock = new WebSocket(url);
+        // Detect if in browser vs in NodeJS
+        var sock = typeof window !== 'undefined' ? new window.WebSocket(url) : new WebSocket(url);
         sock.binaryType = 'arraybuffer';
         this.socket = assign(sock, socketAdapter(this));
       }
@@ -812,5 +814,3 @@ class Ros extends EventEmitter {
     return new SimpleActionServer({ ros: this, ...options });
   }
 }
-
-module.exports = Ros;

--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -3,16 +3,16 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-var ServiceResponse = require('./ServiceResponse');
-var ServiceRequest = require('./ServiceRequest');
-var EventEmitter = require('eventemitter3').EventEmitter;
-var Ros = require('../core/Ros');
+import ServiceResponse from './ServiceResponse.js';
+import ServiceRequest from './ServiceRequest.js';
+import Ros from './Ros.js';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * A ROS service client.
  * @template TRequest, TResponse
  */
-class Service extends EventEmitter {
+export default class Service extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -131,5 +131,3 @@ class Service extends EventEmitter {
     this.ros.callOnConnection(call);
   }
 }
-
-module.exports = Service;

--- a/src/core/ServiceRequest.js
+++ b/src/core/ServiceRequest.js
@@ -3,7 +3,7 @@
  * @author Brandon Alexander - balexander@willowgarage.com
  */
 
-var assign = require('object-assign');
+import assign from 'object-assign';
 
 /**
  * A ServiceRequest is passed into the service call.
@@ -11,7 +11,7 @@ var assign = require('object-assign');
  * @constructor
  * @template T
 */
-class ServiceRequest {
+export default class ServiceRequest {
   /**
    * @param {T} [values={}] - Object matching the fields defined in the .srv definition file.
    */
@@ -19,5 +19,3 @@ class ServiceRequest {
     assign(this, values || {});
   }
 }
-
-module.exports = ServiceRequest;

--- a/src/core/ServiceResponse.js
+++ b/src/core/ServiceResponse.js
@@ -3,7 +3,7 @@
  * @author Brandon Alexander - balexander@willowgarage.com
  */
 
-var assign = require('object-assign');
+import assign from 'object-assign';
 
 /**
  * A ServiceResponse is returned from the service call.
@@ -11,7 +11,7 @@ var assign = require('object-assign');
  * @constructor
  * @template T
 */
-class ServiceResponse {
+export default class ServiceResponse {
   /**
    * @param {T} values - Object matching the fields defined in the .srv definition file.
    */
@@ -19,5 +19,3 @@ class ServiceResponse {
     assign(this, values);
   }
 }
-
-module.exports = ServiceResponse;

--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -6,7 +6,6 @@
  * in the context of their parent object, unless bound
  * @fileOverview
  */
-'use strict';
 
 import decompressPng from '../util/decompressPng.js';
 import CBOR from 'cbor-js';

--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -8,9 +8,9 @@
  */
 'use strict';
 
-var decompressPng = require('../util/decompressPng');
-var CBOR = require('cbor-js');
-var typedArrayTagger = require('../util/cborTypedArrayTags');
+import decompressPng from '../util/decompressPng.js';
+import CBOR from 'cbor-js';
+import typedArrayTagger from '../util/cborTypedArrayTags.js';
 var BSON = null;
 // @ts-expect-error -- Workarounds for not including BSON in bundle. need to revisit
 if (typeof bson !== 'undefined') {
@@ -26,7 +26,7 @@ if (typeof bson !== 'undefined') {
  * @namespace SocketAdapter
  * @private
  */
-function SocketAdapter(client) {
+export default function SocketAdapter(client) {
   var decoder = null;
   if (client.transportOptions.decoder) {
     decoder = client.transportOptions.decoder;
@@ -137,5 +137,3 @@ function SocketAdapter(client) {
     }
   };
 }
-
-module.exports = SocketAdapter;

--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -3,9 +3,9 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-var EventEmitter = require('eventemitter3').EventEmitter;
-var Message = require('./Message');
-var Ros = require('../core/Ros');
+import { EventEmitter } from 'eventemitter3';
+import Message from './Message.js';
+import Ros from './Ros.js';
 
 /**
  * Publish and/or subscribe to a topic in ROS.
@@ -15,7 +15,7 @@ var Ros = require('../core/Ros');
  *  * 'message' - The message data from rosbridge.
  * @template T
  */
-class Topic extends EventEmitter {
+export default class Topic extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -223,5 +223,3 @@ class Topic extends EventEmitter {
     this.ros.callOnConnection(call);
   }
 }
-
-module.exports = Topic;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,10 +1,8 @@
-module.exports = {
-  Ros: require('./Ros'),
-  Topic: require('./Topic'),
-  Message: require('./Message'),
-  Param: require('./Param'),
-  Service: require('./Service'),
-  ServiceRequest: require('./ServiceRequest'),
-  ServiceResponse: require('./ServiceResponse'),
-  Action: require('./Action'),
-};
+export {default as Ros} from './Ros.js';
+export {default as Topic} from './Topic.js';
+export {default as Message} from './Message.js';
+export {default as Param} from './Param.js';
+export {default as Service} from './Service.js';
+export {default as ServiceRequest} from './ServiceRequest.js';
+export {default as ServiceResponse} from './ServiceResponse.js';
+export {default as Action} from './Action.js';

--- a/src/math/Pose.js
+++ b/src/math/Pose.js
@@ -3,14 +3,14 @@
  * @author David Gossow - dgossow@willowgarage.com
  */
 
-var Vector3 = require('./Vector3');
-var Quaternion = require('./Quaternion');
-var Transform = require('./Transform');
+import Vector3 from './Vector3.js';
+import Quaternion from './Quaternion.js';
+import Transform from './Transform.js';
 
 /**
  * A Pose in 3D space. Values are copied into this object.
  */
-class Pose {
+export default class Pose {
   /**
    * @param {Object} [options]
    * @param {Vector3} [options.position] - The ROSLIB.Vector3 describing the position.
@@ -71,5 +71,3 @@ class Pose {
     return inverse;
   }
 }
-
-module.exports = Pose;

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -6,7 +6,7 @@
 /**
  * A Quaternion.
  */
-class Quaternion {
+export default class Quaternion {
   /**
    * @param {Object} [options]
    * @param {number|null} [options.x=0] - The x value.
@@ -88,5 +88,3 @@ class Quaternion {
     return new Quaternion(this);
   }
 }
-
-module.exports = Quaternion;

--- a/src/math/Transform.js
+++ b/src/math/Transform.js
@@ -3,13 +3,13 @@
  * @author David Gossow - dgossow@willowgarage.com
  */
 
-var Vector3 = require('./Vector3');
-var Quaternion = require('./Quaternion');
+import Vector3 from './Vector3.js';
+import Quaternion from './Quaternion.js';
 
 /**
  * A Transform in 3-space. Values are copied into this object.
  */
-class Transform {
+export default class Transform {
   /**
    * @param {Object} options
    * @param {Vector3} options.translation - The ROSLIB.Vector3 describing the translation.
@@ -29,5 +29,3 @@ class Transform {
     return new Transform(this);
   }
 }
-
-module.exports = Transform;

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -3,12 +3,12 @@
  * @author David Gossow - dgossow@willowgarage.com
  */
 
-var Quaternion = require('./Quaternion');
+import Quaternion from './Quaternion.js';
 
 /**
  * A 3D vector.
  */
-class Vector3 {
+export default class Vector3 {
   /**
    * @param {Object} [options]
    * @param {number} [options.x=0] - The x value.
@@ -64,5 +64,3 @@ class Vector3 {
     return new Vector3(this);
   }
 }
-
-module.exports = Vector3;

--- a/src/math/index.js
+++ b/src/math/index.js
@@ -1,6 +1,4 @@
-module.exports = {
-  Pose: require('./Pose'),
-  Quaternion: require('./Quaternion'),
-  Transform: require('./Transform'),
-  Vector3: require('./Vector3')
-};
+export { default as Pose } from './Pose.js';
+export { default as Quaternion } from './Quaternion.js';
+export { default as Transform } from './Transform.js';
+export { default as Vector3 } from './Vector3.js';

--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -3,22 +3,22 @@
  * @author David Gossow - dgossow@willowgarage.com
  */
 
-var EventEmitter = require('eventemitter3').EventEmitter;
-var ActionClient = require('../actionlib/ActionClient');
-var Goal = require('../actionlib/Goal');
+import ActionClient from '../actionlib/ActionClient.js';
+import Goal from '../actionlib/Goal.js';
 
-var Service = require('../core/Service.js');
-var ServiceRequest = require('../core/ServiceRequest.js');
-var Topic = require('../core/Topic.js');
+import Service from '../core/Service.js';
+import ServiceRequest from '../core/ServiceRequest.js';
+import Topic from '../core/Topic.js';
 
-var Transform = require('../math/Transform');
+import Transform from '../math/Transform.js';
 
-var Ros = require('../core/Ros');
+import Ros from '../core/Ros.js';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * A TF Client that listens to TFs from tf2_web_republisher.
  */
-class TFClient extends EventEmitter {
+export default class TFClient extends EventEmitter {
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -229,5 +229,3 @@ class TFClient extends EventEmitter {
     }
   }
 }
-
-module.exports = TFClient;

--- a/src/tf/index.js
+++ b/src/tf/index.js
@@ -1,3 +1,1 @@
-module.exports = {
-  TFClient: require('./TFClient')
-};
+export { default as TFClient } from './TFClient.js';

--- a/src/urdf/UrdfBox.js
+++ b/src/urdf/UrdfBox.js
@@ -4,13 +4,13 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var Vector3 = require('../math/Vector3');
-var UrdfTypes = require('./UrdfTypes');
+import Vector3 from '../math/Vector3.js';
+import * as UrdfTypes from './UrdfTypes.js';
 
 /**
  * A Box element in a URDF.
  */
-class UrdfBox {
+export default class UrdfBox {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -29,5 +29,3 @@ class UrdfBox {
     });
   }
 }
-
-module.exports = UrdfBox;

--- a/src/urdf/UrdfColor.js
+++ b/src/urdf/UrdfColor.js
@@ -7,7 +7,7 @@
 /**
  * A Color element in a URDF.
  */
-class UrdfColor {
+export default class UrdfColor {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -22,5 +22,3 @@ class UrdfColor {
     this.a = parseFloat(rgba[3]);
   }
 }
-
-module.exports = UrdfColor;

--- a/src/urdf/UrdfCylinder.js
+++ b/src/urdf/UrdfCylinder.js
@@ -4,12 +4,12 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var UrdfTypes = require('./UrdfTypes');
+import * as UrdfTypes from './UrdfTypes.js';
 
 /**
  * A Cylinder element in a URDF.
  */
-class UrdfCylinder {
+export default class UrdfCylinder {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -22,5 +22,3 @@ class UrdfCylinder {
     this.radius = parseFloat(options.xml.getAttribute('radius'));
   }
 }
-
-module.exports = UrdfCylinder;

--- a/src/urdf/UrdfJoint.js
+++ b/src/urdf/UrdfJoint.js
@@ -3,14 +3,14 @@
  * @author David V. Lu!! - davidvlu@gmail.com
  */
 
-var Pose = require('../math/Pose');
-var Vector3 = require('../math/Vector3');
-var Quaternion = require('../math/Quaternion');
+import Pose from '../math/Pose.js';
+import Vector3 from '../math/Vector3.js';
+import Quaternion from '../math/Quaternion.js';
 
 /**
  * A Joint element in a URDF.
  */
-class UrdfJoint {
+export default class UrdfJoint {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -93,5 +93,3 @@ class UrdfJoint {
     }
   }
 }
-
-module.exports = UrdfJoint;

--- a/src/urdf/UrdfLink.js
+++ b/src/urdf/UrdfLink.js
@@ -4,12 +4,12 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var UrdfVisual = require('./UrdfVisual');
+import UrdfVisual from './UrdfVisual.js';
 
 /**
  * A Link element in a URDF.
  */
-class UrdfLink {
+export default class UrdfLink {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -28,5 +28,3 @@ class UrdfLink {
     }
   }
 }
-
-module.exports = UrdfLink;

--- a/src/urdf/UrdfMaterial.js
+++ b/src/urdf/UrdfMaterial.js
@@ -4,12 +4,12 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var UrdfColor = require('./UrdfColor');
+import UrdfColor from './UrdfColor.js';
 
 /**
  * A Material element in a URDF.
  */
-class UrdfMaterial {
+export default class UrdfMaterial {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -43,6 +43,4 @@ class UrdfMaterial {
   }
 }
 
-var assign = require('object-assign');
-
-module.exports = UrdfMaterial;
+import assign from 'object-assign';

--- a/src/urdf/UrdfMesh.js
+++ b/src/urdf/UrdfMesh.js
@@ -4,13 +4,13 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var Vector3 = require('../math/Vector3');
-var UrdfTypes = require('./UrdfTypes');
+import Vector3 from '../math/Vector3.js';
+import * as UrdfTypes from './UrdfTypes.js';
 
 /**
  * A Mesh element in a URDF.
  */
-class UrdfMesh {
+export default class UrdfMesh {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -34,5 +34,3 @@ class UrdfMesh {
     }
   }
 }
-
-module.exports = UrdfMesh;

--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -4,10 +4,10 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var UrdfMaterial = require('./UrdfMaterial');
-var UrdfLink = require('./UrdfLink');
-var UrdfJoint = require('./UrdfJoint');
-var DOMParser = require('@xmldom/xmldom').DOMParser;
+import UrdfMaterial from './UrdfMaterial.js';
+import UrdfLink from './UrdfLink.js';
+import UrdfJoint from './UrdfJoint.js';
+import { DOMParser } from '@xmldom/xmldom';
 
 // See https://developer.mozilla.org/docs/XPathResult#Constants
 var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
@@ -15,7 +15,7 @@ var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
 /**
  * A URDF Model can be used to parse a given URDF into the appropriate elements.
  */
-class UrdfModel {
+export default class UrdfModel {
   /**
    * @param {Object} options
    * @param {Element} [options.xml] - The XML element to parse.
@@ -96,5 +96,3 @@ class UrdfModel {
     }
   }
 }
-
-module.exports = UrdfModel;

--- a/src/urdf/UrdfSphere.js
+++ b/src/urdf/UrdfSphere.js
@@ -4,12 +4,12 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var UrdfTypes = require('./UrdfTypes');
+import * as UrdfTypes from './UrdfTypes.js';
 
 /**
  * A Sphere element in a URDF.
  */
-class UrdfSphere {
+export default class UrdfSphere {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -19,5 +19,3 @@ class UrdfSphere {
     this.radius = parseFloat(options.xml.getAttribute('radius') || 'NaN');
   }
 }
-
-module.exports = UrdfSphere;

--- a/src/urdf/UrdfTypes.js
+++ b/src/urdf/UrdfTypes.js
@@ -1,6 +1,4 @@
-module.exports = {
-  URDF_SPHERE: 0,
-  URDF_BOX: 1,
-  URDF_CYLINDER: 2,
-  URDF_MESH: 3
-};
+export const URDF_SPHERE = 0;
+export const URDF_BOX = 1;
+export const URDF_CYLINDER = 2;
+export const URDF_MESH = 3;

--- a/src/urdf/UrdfVisual.js
+++ b/src/urdf/UrdfVisual.js
@@ -4,20 +4,20 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-var Pose = require('../math/Pose');
-var Vector3 = require('../math/Vector3');
-var Quaternion = require('../math/Quaternion');
+import Pose from '../math/Pose.js';
+import Vector3 from '../math/Vector3.js';
+import Quaternion from '../math/Quaternion.js';
 
-var UrdfCylinder = require('./UrdfCylinder');
-var UrdfBox = require('./UrdfBox');
-var UrdfMaterial = require('./UrdfMaterial');
-var UrdfMesh = require('./UrdfMesh');
-var UrdfSphere = require('./UrdfSphere');
+import UrdfCylinder from './UrdfCylinder.js';
+import UrdfBox from './UrdfBox.js';
+import UrdfMaterial from './UrdfMaterial.js';
+import UrdfMesh from './UrdfMesh.js';
+import UrdfSphere from './UrdfSphere.js';
 
 /**
  * A Visual element in a URDF.
  */
-class UrdfVisual {
+export default class UrdfVisual {
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
@@ -136,5 +136,3 @@ class UrdfVisual {
     }
   }
 }
-
-module.exports = UrdfVisual;

--- a/src/urdf/index.js
+++ b/src/urdf/index.js
@@ -1,12 +1,11 @@
-module.exports = {
-  UrdfBox: require('./UrdfBox'),
-  UrdfColor: require('./UrdfColor'),
-  UrdfCylinder: require('./UrdfCylinder'),
-  UrdfLink: require('./UrdfLink'),
-  UrdfMaterial: require('./UrdfMaterial'),
-  UrdfMesh: require('./UrdfMesh'),
-  UrdfModel: require('./UrdfModel'),
-  UrdfSphere: require('./UrdfSphere'),
-  UrdfVisual: require('./UrdfVisual'),
-  ...require('./UrdfTypes')
-};
+export { default as UrdfBox } from './UrdfBox.js';
+export { default as UrdfColor } from './UrdfColor.js';
+export { default as UrdfCylinder } from './UrdfCylinder.js';
+export { default as UrdfLink } from './UrdfLink.js';
+export { default as UrdfMaterial } from './UrdfMaterial.js';
+export { default as UrdfMesh } from './UrdfMesh.js';
+export { default as UrdfModel } from './UrdfModel.js';
+export { default as UrdfSphere } from './UrdfSphere.js';
+export { default as UrdfVisual } from './UrdfVisual.js';
+
+export * from './UrdfTypes.js';

--- a/src/util/cborTypedArrayTags.js
+++ b/src/util/cborTypedArrayTags.js
@@ -105,7 +105,7 @@ var conversionArrayTypes = {
  * @param {Uint8Array} data
  * @param {Number} tag
  */
-function cborTypedArrayTagger(data, tag) {
+export default function cborTypedArrayTagger(data, tag) {
   if (tag in nativeArrayTypes) {
     var arrayType = nativeArrayTypes[tag];
     return decodeNativeArray(data, arrayType);
@@ -114,8 +114,4 @@ function cborTypedArrayTagger(data, tag) {
     return conversionArrayTypes[tag](data);
   }
   return data;
-}
-
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = cborTypedArrayTagger;
 }

--- a/src/util/cborTypedArrayTags.js
+++ b/src/util/cborTypedArrayTags.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var UPPER32 = Math.pow(2, 32);
 
 var warnedPrecision = false;

--- a/src/util/decompressPng.js
+++ b/src/util/decompressPng.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-var pngparse = require('pngparse');
+import pngparse from 'pngparse';
 
 /**
  * @callback decompressPngCallback
@@ -20,7 +20,7 @@ var pngparse = require('pngparse');
  * @param data - An object containing the PNG data.
  * @param {decompressPngCallback} callback - Function with the following params:
  */
-function decompressPng(data, callback) {
+export default function decompressPng(data, callback) {
   var buffer = new Buffer(data, 'base64');
 
   pngparse.parse(buffer, function (err, data) {
@@ -32,5 +32,3 @@ function decompressPng(data, callback) {
     }
   });
 }
-
-module.exports = decompressPng;

--- a/src/util/decompressPng.js
+++ b/src/util/decompressPng.js
@@ -3,8 +3,6 @@
  * @author Ramon Wijnands - rayman747@hotmail.com
  */
 
-'use strict';
-
 import pngparse from 'pngparse';
 
 /**

--- a/src/util/shim/@xmldom/xmldom.js
+++ b/src/util/shim/@xmldom/xmldom.js
@@ -1,3 +1,0 @@
-exports.DOMImplementation = window.DOMImplementation;
-exports.XMLSerializer = window.XMLSerializer;
-exports.DOMParser = window.DOMParser;

--- a/src/util/shim/WebSocket.js
+++ b/src/util/shim/WebSocket.js
@@ -1,1 +1,0 @@
-module.exports = typeof window !== 'undefined' ? window.WebSocket : WebSocket;

--- a/src/util/shim/canvas.js
+++ b/src/util/shim/canvas.js
@@ -1,4 +1,4 @@
 /* global document */
-module.exports = function Canvas() {
+export default function Canvas() {
   return document.createElement('canvas');
 };

--- a/src/util/shim/decompressPng.js
+++ b/src/util/shim/decompressPng.js
@@ -6,7 +6,7 @@
 'use strict';
 
 // @ts-expect-error -- this is for optionally polyfilling canvas
-var Canvas = require('canvas');
+import Canvas from 'canvas';
 var Image = Canvas.Image || window.Image;
 
 /**
@@ -22,7 +22,7 @@ var Image = Canvas.Image || window.Image;
  * @param data - An object containing the PNG data.
  * @param {decompressPngCallback} callback - Function with the following params:
  */
-function decompressPng(data, callback) {
+export default function decompressPng(data, callback) {
   // Uncompresses the data before sending it through (use image/canvas to do so).
   var image = new Image();
   // When the image loads, extracts the raw data (JSON message).
@@ -60,5 +60,3 @@ function decompressPng(data, callback) {
   // Sends the image data to load.
   image.src = 'data:image/png;base64,' + data;
 }
-
-module.exports = decompressPng;

--- a/src/util/shim/decompressPng.js
+++ b/src/util/shim/decompressPng.js
@@ -3,8 +3,6 @@
  * @author Graeme Yeates - github.com/megawac
  */
 
-'use strict';
-
 // @ts-expect-error -- this is for optionally polyfilling canvas
 import Canvas from 'canvas';
 var Image = Canvas.Image || window.Image;

--- a/test/cbor.test.js
+++ b/test/cbor.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-var CBOR = require('cbor-js');
-var cborTypedArrayTagger = require('../src/util/cborTypedArrayTags.js');
+import CBOR from 'cbor-js';
+import cborTypedArrayTagger from '../src/util/cborTypedArrayTags.js';
 
 /** Convert hex string to ArrayBuffer. */
 function hexToBuffer(hex) {

--- a/test/examples/check-topics.example.js
+++ b/test/examples/check-topics.example.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 var expectedTopics = [
     // '/turtle1/cmd_vel', '/turtle1/color_sensor', '/turtle1/pose',

--- a/test/examples/fibonacci.example.js
+++ b/test/examples/fibonacci.example.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 describe('Fibonacci Example', function() {
     it('Fibonacci', () => new Promise((done) =>  {
@@ -52,3 +52,4 @@ describe('Fibonacci Example', function() {
         }, 100);
     }), 8000);
 });
+

--- a/test/examples/params.examples.js
+++ b/test/examples/params.examples.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 describe('Param setting', function() {
     var ros = new ROSLIB.Ros({

--- a/test/examples/pubsub.example.js
+++ b/test/examples/pubsub.example.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterAll } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 describe('Topics Example', function() {
 
@@ -97,3 +97,4 @@ describe('Topics Example', function() {
         example2.unsubscribe();
     });
 }, 1000);
+

--- a/test/examples/tf.example.js
+++ b/test/examples/tf.example.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 describe('TF2 Republisher Example', function() {
     it('tf republisher', () => new Promise((done) =>  {

--- a/test/examples/tf_service.example.js
+++ b/test/examples/tf_service.example.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 describe('TF2 Republisher Service Example', function() {
     it('tf republisher', () => new Promise((done) =>  {

--- a/test/examples/topic-listener.example.js
+++ b/test/examples/topic-listener.example.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('../..');
+import * as ROSLIB from '../../src/RosLib.js';
 
 var ros = new ROSLIB.Ros({
     url: 'ws://localhost:9090'

--- a/test/math-examples.test.js
+++ b/test/math-examples.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('..');
+import * as ROSLIB from '../src/RosLib.js';
 
 function clone(x) {
     var y = {};

--- a/test/quaternion.test.js
+++ b/test/quaternion.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('..');
+import * as ROSLIB from '../src/RosLib.js';
 
 
 describe('Quaternion', function() {

--- a/test/tfclient.test.js
+++ b/test/tfclient.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('..');
+import * as ROSLIB from '../src/RosLib.js';
 
 describe('TFClient', function() {
 

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('..');
+import * as ROSLIB from '../src/RosLib.js';
 
 describe('Transform', function() {
 

--- a/test/urdf.test.js
+++ b/test/urdf.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-var ROSLIB = require('..');
+import * as ROSLIB from '../src/RosLib.js';
 
-var DOMParser = require('@xmldom/xmldom').DOMParser;
+import { DOMParser } from '@xmldom/xmldom';
 // See https://developer.mozilla.org/docs/XPathResult#Constants
 var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "Node16" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
     "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
@@ -13,6 +13,8 @@
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": false /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+    "moduleResolution": "Node16",
+    "types": ["@types/node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

This is _definitely a breaking change_. Code requiring CommonJS modules may no longer work the same way or at all.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

This removes usage of the old CommonJS module `require` syntax in favor of ECMAScript Module `import` syntax, to ease the adoption of a newer bundler like Rollup. This code works in my Vite-based codebase, so it should work in Rollup.

The bulk of this PR is a change to `package-lock.json` from shuffling dependencies around.

<!-- Link relevant GitHub issues -->
Related to desire for a better/newer bundler in #647.
