### PR TITLE
Use explicit vitest API

### DIFF
--- a/examples/react-example/src/App.test.jsx
+++ b/examples/react-example/src/App.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import App from './App'
 import React from "react";
+import { expect, test } from "vitest";
 
 test('renders learn react link', () => {
   render(<App />)

--- a/test/cbor.test.js
+++ b/test/cbor.test.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from 'vitest';
 var CBOR = require('cbor-js');
 var cborTypedArrayTagger = require('../src/util/cborTypedArrayTags.js');
 

--- a/test/examples/check-topics.example.js
+++ b/test/examples/check-topics.example.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('../..');
 
 var expectedTopics = [

--- a/test/examples/fibonacci.example.js
+++ b/test/examples/fibonacci.example.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('../..');
 
 describe('Fibonacci Example', function() {

--- a/test/examples/params.examples.js
+++ b/test/examples/params.examples.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('../..');
 
 describe('Param setting', function() {

--- a/test/examples/pubsub.example.js
+++ b/test/examples/pubsub.example.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect, afterAll } from 'vitest';
 var ROSLIB = require('../..');
 
 describe('Topics Example', function() {

--- a/test/examples/tf.example.js
+++ b/test/examples/tf.example.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('../..');
 
 describe('TF2 Republisher Example', function() {

--- a/test/examples/tf_service.example.js
+++ b/test/examples/tf_service.example.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('../..');
 
 describe('TF2 Republisher Service Example', function() {

--- a/test/examples/topic-listener.example.js
+++ b/test/examples/topic-listener.example.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from 'vitest';
 var ROSLIB = require('../..');
 
 var ros = new ROSLIB.Ros({

--- a/test/math-examples.test.js
+++ b/test/math-examples.test.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from 'vitest';
 var ROSLIB = require('..');
 
 function clone(x) {

--- a/test/quaternion.test.js
+++ b/test/quaternion.test.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('..');
 
 

--- a/test/tfclient.test.js
+++ b/test/tfclient.test.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('..');
 
 describe('TFClient', function() {

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from "vitest";
 var ROSLIB = require('..');
 
 describe('Transform', function() {

--- a/test/urdf.test.js
+++ b/test/urdf.test.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect;
+import { describe, it, expect } from 'vitest';
 var ROSLIB = require('..');
 
 var DOMParser = require('@xmldom/xmldom').DOMParser;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": false /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     "skipLibCheck": true, /* Skip type checking all .d.ts files. */
-    "types": ["vitest/globals"]
   },
   "include": ["src"]
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,7 +2,6 @@ import {defineConfig} from "vitest/config";
 
 export default defineConfig({
   test: {
-    globals: true,
     include: [
       // Default value for vitest; we just want to extend.
       '**\/*.{test,spec}.?(c|m)[jt]s?(x)',


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

The global injection of describe, it, expect, etc. is just meant to help with migration from earlier frameworks. This PR just goes around adding the imports where appropriate.

<!-- Link relevant GitHub issues -->
