### PR TITLE
global -> globalThis

### DIFF
--- a/src/RosLib.js
+++ b/src/RosLib.js
@@ -18,7 +18,7 @@ import * as Tf from './tf/index.js';
 import * as Urdf from './urdf/index.js';
 
 // Add to global namespace for in-browser support (i.e. CDN)
-global.ROSLIB = {
+globalThis.ROSLIB = {
   REVISION,
   ...Core,
   ...ActionLib,


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
Fixes a bug I introduced with usage of the global ROSLIB object.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

`global` doesn't exist in browsers but does in Node.js.
`window` doesn't exist in Node.js but does exist in browsers.
`globalThis` exists in both, acting as a proxy to the appropriate one.

Fixes a bug where importing roslib class-by-class works fine but importing the whole library in a browser application throws a ReferenceError.

<!-- Link relevant GitHub issues -->
