### PR TITLE
Fix Service.advertise callback type

### DIFF
--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -74,9 +74,8 @@ export default class Service extends EventEmitter {
   /**
    * @callback advertiseCallback
    * @param {TRequest} request - The service request.
-   * @param {Object} response - An empty dictionary. Take care not to overwrite this. Instead, only modify the values within.
-   *     It should return true if the service has finished successfully,
-   *     i.e., without any fatal errors.
+   * @param {Partial<TResponse>} response - An empty dictionary. Take care not to overwrite this. Instead, only modify the values within.
+   * @returns {boolean} true if the service has finished successfully, i.e., without any fatal errors.
    */
   /**
    * Advertise the service. This turns the Service object from a client


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
Changes the TypeScript type to be consistent with the actual usage of the Service.advertise API.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->


<!-- Link relevant GitHub issues -->
