### PR TITLE
Add `advertiseAsync` method to `Service`

### DIFF
--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,0 +1,28 @@
+import { it, describe, expect } from 'vitest';
+import { Service, Ros } from '../';
+
+describe('Service', () => {
+  const ros = new Ros({
+    url: 'ws://localhost:9090'
+  });
+  it('Successfully advertises a service with an async return', async () => {
+    const server = new Service({
+      ros,
+      serviceType: 'std_srvs/Trigger',
+      name: '/test_service'
+    });
+    server.advertiseAsync(async () => {
+      return {
+        success: true,
+        message: 'foo'
+      }
+    });
+    const client = new Service({
+      ros,
+      serviceType: 'std_srvs/Trigger',
+      name: '/test_service'
+    })
+    const response = await new Promise((resolve, reject) => client.callService({}, resolve, reject));
+    expect(response).toEqual({success: true, message: 'foo'});
+  })
+})


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
Adds an `advertiseAsync` function to the `Service` class to allow Promise-returning functions as callbacks to services.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
☝🏻 
This is useful for cases where, like a feature I'm working on right now in my application, you want to wait to return a Service call until a different asynchronous operation completes. The original `advertise` function is very limiting because it requires all operations undertaken by the Service server to be synchronous due to the design of asynchronicity in JavaScript disincentivizing synchronizing async closures into synchronous ones.


<!-- Link relevant GitHub issues -->
