### PR TITLE
Fix un-advertisement and multiple-advertisement of Service callbacks

### DIFF
--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -12,6 +12,12 @@ import { EventEmitter } from 'eventemitter3';
  */
 export default class Service extends EventEmitter {
   /**
+     * Stores a reference to the most recent service callback advertised so it can be removed from the EventEmitter during un-advertisement
+     * @private
+     * @type {((rosbridgeRequest) => any) | null}
+     */
+  _serviceCallback = null;
+  /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
    * @param {string} options.name - The service name, like '/add_two_ints'.
@@ -23,12 +29,6 @@ export default class Service extends EventEmitter {
     this.name = options.name;
     this.serviceType = options.serviceType;
     this.isAdvertised = false;
-
-    /**
-     * Stores a reference to the most recent service callback advertised so it can be removed from the EventEmitter during un-advertisement
-     * @type {((rosbridgeRequest) => any) | null}
-     */
-    this._serviceCallback = null;
   }
   /**
    * @callback callServiceCallback

--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -17,6 +17,7 @@ export default class Service extends EventEmitter {
      * @type {((rosbridgeRequest) => any) | null}
      */
   _serviceCallback = null;
+  isAdvertised = false;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -28,7 +29,6 @@ export default class Service extends EventEmitter {
     this.ros = options.ros;
     this.name = options.name;
     this.serviceType = options.serviceType;
-    this.isAdvertised = false;
   }
   /**
    * @callback callServiceCallback

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -24,5 +24,32 @@ describe('Service', () => {
     })
     const response = await new Promise((resolve, reject) => client.callService({}, resolve, reject));
     expect(response).toEqual({success: true, message: 'foo'});
+    // Make sure un-advertisement actually disposes of the event handler
+    expect(ros.listenerCount(server.name)).toEqual(1);
+    server.unadvertise();
+    expect(ros.listenerCount(server.name)).toEqual(0);
+  })
+  it('Successfully advertises a service with a synchronous return', async () => {
+    const server = new Service({
+      ros,
+      serviceType: 'std_srvs/Trigger',
+      name: '/test_service'
+    });
+    server.advertise((request, response) => {
+      response.success = true;
+      response.message = 'bar';
+      return true;
+    });
+    const client = new Service({
+      ros,
+      serviceType: 'std_srvs/Trigger',
+      name: '/test_service'
+    })
+    const response = await new Promise((resolve, reject) => client.callService({}, resolve, reject));
+    expect(response).toEqual({success: true, message: 'bar'});
+    // Make sure un-advertisement actually disposes of the event handler
+    expect(ros.listenerCount(server.name)).toEqual(1);
+    server.unadvertise();
+    expect(ros.listenerCount(server.name)).toEqual(0);
   })
 })


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
Calling `Service.advertise` multiple times now throws an error, as suggested in #698.
Bugfix: prevent resource leak of Service callbacks

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
As noted in #698, Service un-advertisement apparently has never removed the callback from the service server, which is probably not good.. for both resource leak reasons and possible unexpected behavior reasons like a callback being invoked even after unadvertisement.

<!-- Link relevant GitHub issues -->
