### PR TITLE
Clean up constantly initialized class members

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@testing-library/react": "^14.2.1",
         "@types/node": "^20.11.19",
+        "@types/ws": "^8.5.10",
         "eslint": "^8.56.0",
         "globals": "^14.0.0",
         "jsdoc": "^4.0.2",
@@ -1285,6 +1286,15 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@testing-library/react": "^14.2.1",
     "@types/node": "^20.11.19",
+    "@types/ws": "^8.5.10",
     "eslint": "^8.56.0",
     "globals": "^14.0.0",
     "jsdoc": "^4.0.2",

--- a/src/actionlib/ActionListener.js
+++ b/src/actionlib/ActionListener.js
@@ -27,7 +27,6 @@ export default class ActionListener extends EventEmitter {
    */
   constructor(options) {
     super();
-    var that = this;
     this.ros = options.ros;
     this.serverName = options.serverName;
     this.actionName = options.actionName;
@@ -57,25 +56,25 @@ export default class ActionListener extends EventEmitter {
       messageType: this.actionName + 'Result'
     });
 
-    goalListener.subscribe(function (goalMessage) {
-      that.emit('goal', goalMessage);
+    goalListener.subscribe((goalMessage) => {
+      this.emit('goal', goalMessage);
     });
 
-    statusListener.subscribe(function (statusMessage) {
-      statusMessage.status_list.forEach(function (status) {
-        that.emit('status', status);
+    statusListener.subscribe((statusMessage) => {
+      statusMessage.status_list.forEach((status) => {
+        this.emit('status', status);
       });
     });
 
-    feedbackListener.subscribe(function (feedbackMessage) {
-      that.emit('status', feedbackMessage.status);
-      that.emit('feedback', feedbackMessage.feedback);
+    feedbackListener.subscribe((feedbackMessage) => {
+      this.emit('status', feedbackMessage.status);
+      this.emit('feedback', feedbackMessage.feedback);
     });
 
     // subscribe to the result topic
-    resultListener.subscribe(function (resultMessage) {
-      that.emit('status', resultMessage.status);
-      that.emit('result', resultMessage.result);
+    resultListener.subscribe((resultMessage) => {
+      this.emit('status', resultMessage.status);
+      this.emit('result', resultMessage.result);
     });
   }
 }

--- a/src/actionlib/Goal.js
+++ b/src/actionlib/Goal.js
@@ -14,6 +14,12 @@ import ActionClient from './ActionClient.js';
  *  * 'timeout' - If a timeout occurred while sending a goal.
  */
 export default class Goal extends EventEmitter {
+  isFinished = false;
+  status = undefined;
+  result = undefined;
+  feedback = undefined;
+  // Create a random ID
+  goalID = 'goal_' + Math.random() + '_' + new Date().getTime();
   /**
    * @param {Object} options
    * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.
@@ -21,19 +27,8 @@ export default class Goal extends EventEmitter {
    */
   constructor(options) {
     super();
-    var that = this;
     this.actionClient = options.actionClient;
-    this.goalMessage = options.goalMessage;
-    this.isFinished = false;
-    this.status = undefined;
-    this.result = undefined;
-    this.feedback = undefined;
 
-    // Used to create random IDs
-    var date = new Date();
-
-    // Create a random ID
-    this.goalID = 'goal_' + Math.random() + '_' + date.getTime();
     // Fill in the goal message
     this.goalMessage = {
       goal_id: {
@@ -43,20 +38,20 @@ export default class Goal extends EventEmitter {
         },
         id: this.goalID
       },
-      goal: this.goalMessage
+      goal: options.goalMessage
     };
 
-    this.on('status', function (status) {
-      that.status = status;
+    this.on('status', (status) => {
+      this.status = status;
     });
 
-    this.on('result', function (result) {
-      that.isFinished = true;
-      that.result = result;
+    this.on('result', (result) => {
+      this.isFinished = true;
+      this.result = result;
     });
 
-    this.on('feedback', function (feedback) {
-      that.feedback = feedback;
+    this.on('feedback', (feedback) => {
+      this.feedback = feedback;
     });
 
     // Add the goal
@@ -68,12 +63,11 @@ export default class Goal extends EventEmitter {
    * @param {number} [timeout] - A timeout length for the goal's result.
    */
   send(timeout) {
-    var that = this;
-    that.actionClient.goalTopic.publish(that.goalMessage);
+    this.actionClient.goalTopic.publish(this.goalMessage);
     if (timeout) {
-      setTimeout(function () {
-        if (!that.isFinished) {
-          that.emit('timeout');
+      setTimeout(() => {
+        if (!this.isFinished) {
+          this.emit('timeout');
         }
       }, timeout);
     }

--- a/src/core/Action.js
+++ b/src/core/Action.js
@@ -11,6 +11,26 @@ import Ros from '../core/Ros.js';
  * @template TGoal, TFeedback, TResult
  */
 export default class Action extends EventEmitter {
+  isAdvertised = false;
+  /**
+   * @callback advertiseActionCallback
+   * @param {TGoal} goal - The action goal.
+   * @param {string} id - The ID of the action goal to execute.
+   */
+  /**
+   * @private
+   * @type {advertiseActionCallback | null}
+   */
+  _actionCallback = null;
+  /**
+   * @callback advertiseCancelCallback
+   * @param {string} id - The ID of the action goal to cancel.
+   */
+  /**
+   * @private
+   * @type {advertiseCancelCallback | null}
+   */
+  _cancelCallback = null;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
@@ -22,10 +42,6 @@ export default class Action extends EventEmitter {
     this.ros = options.ros;
     this.name = options.name;
     this.actionType = options.actionType;
-    this.isAdvertised = false;
-
-    this._actionCallback = null;
-    this._cancelCallback = null;
   }
 
   /**
@@ -105,15 +121,6 @@ export default class Action extends EventEmitter {
     this.ros.callOnConnection(call);
   }
 
-  /**
-   * @callback advertiseActionCallback
-   * @param {TGoal} goal - The action goal.
-   * @param {string} id - The ID of the action goal to execute.
-   */
-  /**
-   * @callback advertiseCancelCallback
-   * @param {string} id - The ID of the action goal to cancel.
-   */
   /**
    * Advertise the action. This turns the Action object from a client
    * into a server. The callback will be called with every goal sent to this action.

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -63,19 +63,18 @@ export default class Ros extends EventEmitter {
     } else if (this.transportLibrary === 'websocket') {
       if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
         // Detect if in browser vs in NodeJS
-        if (typeof window !== undefined) {
-          this.socket = new WebSocket(url);
-          this.socket.binaryType = 'arraybuffer';
+        if (typeof window !== 'undefined') {
+          const sock = new WebSocket(url);
+          sock.binaryType = 'arraybuffer';
+          this.socket = Object.assign(sock, socketAdapter(this));
         } else {
           // if in Node.js, import ws to replace browser WebSocket API
           import('ws').then((ws) => {
-            this.socket = new ws.WebSocket(url);
-            this.socket.binaryType = 'arraybuffer'
+            const sock = new ws.WebSocket(url);
+            sock.binaryType = 'arraybuffer'
+            this.socket = Object.assign(sock, socketAdapter(this));
           })
         }
-        var sock = typeof window !== 'undefined' ? new window.WebSocket(url) : new WebSocket(url);
-        sock.binaryType = 'arraybuffer';
-        this.socket = Object.assign(sock, socketAdapter(this));
       }
     } else {
       throw 'Unknown transportLibrary: ' + this.transportLibrary.toString();

--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -90,7 +90,7 @@ export default class Topic extends EventEmitter {
     }
   }
 
-  _messageCallback(data) {
+  _messageCallback = (data) => {
     this.emit('message', data);
   };
   /**

--- a/src/urdf/UrdfBox.js
+++ b/src/urdf/UrdfBox.js
@@ -11,21 +11,25 @@ import * as UrdfTypes from './UrdfTypes.js';
  * A Box element in a URDF.
  */
 export default class UrdfBox {
+  /** @type {Vector3 | null} */
+  dimension;
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
    */
   constructor(options) {
-    this.dimension = null;
     this.type = UrdfTypes.URDF_BOX;
 
     // Parse the xml string
-    // @ts-expect-error -- possibly null
-    var xyz = options.xml.getAttribute('size').split(' ');
-    this.dimension = new Vector3({
-      x: parseFloat(xyz[0]),
-      y: parseFloat(xyz[1]),
-      z: parseFloat(xyz[2])
-    });
+    var xyz = options.xml.getAttribute('size')?.split(' ');
+    if (xyz) {
+      this.dimension = new Vector3({
+        x: parseFloat(xyz[0]),
+        y: parseFloat(xyz[1]),
+        z: parseFloat(xyz[2])
+      });
+    } else {
+      this.dimension = null;
+    }
   }
 }

--- a/src/urdf/UrdfColor.js
+++ b/src/urdf/UrdfColor.js
@@ -14,11 +14,12 @@ export default class UrdfColor {
    */
   constructor(options) {
     // Parse the xml string
-    // @ts-expect-error -- possibly null
-    var rgba = options.xml.getAttribute('rgba').split(' ');
-    this.r = parseFloat(rgba[0]);
-    this.g = parseFloat(rgba[1]);
-    this.b = parseFloat(rgba[2]);
-    this.a = parseFloat(rgba[3]);
+    var rgba = options.xml.getAttribute('rgba')?.split(' ');
+    if (rgba) {
+      this.r = parseFloat(rgba[0]);
+      this.g = parseFloat(rgba[1]);
+      this.b = parseFloat(rgba[2]);
+      this.a = parseFloat(rgba[3]);
+    }
   }
 }

--- a/src/urdf/UrdfMaterial.js
+++ b/src/urdf/UrdfMaterial.js
@@ -10,13 +10,15 @@ import UrdfColor from './UrdfColor.js';
  * A Material element in a URDF.
  */
 export default class UrdfMaterial {
+  /** @type {string | null} */
+  textureFilename = null;
+  /** @type {UrdfColor | null} */
+  color = null;
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
    */
   constructor(options) {
-    this.textureFilename = null;
-    this.color = null;
 
     this.name = options.xml.getAttribute('name');
 

--- a/src/urdf/UrdfMesh.js
+++ b/src/urdf/UrdfMesh.js
@@ -11,13 +11,13 @@ import * as UrdfTypes from './UrdfTypes.js';
  * A Mesh element in a URDF.
  */
 export default class UrdfMesh {
+  /** @type {Vector3 | null} */
+  scale = null;
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
    */
   constructor(options) {
-    this.scale = null;
-
     this.type = UrdfTypes.URDF_MESH;
     this.filename = options.xml.getAttribute('filename');
 

--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -16,6 +16,9 @@ var XPATH_FIRST_ORDERED_NODE_TYPE = 9;
  * A URDF Model can be used to parse a given URDF into the appropriate elements.
  */
 export default class UrdfModel {
+  materials = {};
+  links = {};
+  joints = {};
   /**
    * @param {Object} options
    * @param {Element} [options.xml] - The XML element to parse.
@@ -24,9 +27,6 @@ export default class UrdfModel {
   constructor(options) {
     var xmlDoc = options.xml;
     var string = options.string;
-    this.materials = {};
-    this.links = {};
-    this.joints = {};
 
     // Check if we are using a string or an XML element
     if (string) {

--- a/src/urdf/UrdfVisual.js
+++ b/src/urdf/UrdfVisual.js
@@ -18,16 +18,18 @@ import UrdfSphere from './UrdfSphere.js';
  * A Visual element in a URDF.
  */
 export default class UrdfVisual {
+  /** @type {Pose | null} */
+  origin = null;
+  /** @type {UrdfMesh | UrdfSphere | UrdfBox | UrdfCylinder | null} */
+  geometry = null;
+  /** @type {UrdfMaterial | null} */
+  material = null;
   /**
    * @param {Object} options
    * @param {Element} options.xml - The XML element to parse.
    */
   constructor(options) {
     var xml = options.xml;
-    this.origin = null;
-    this.geometry = null;
-    this.material = null;
-
     this.name = options.xml.getAttribute('name');
 
     // Origin


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
hopefully none

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
There are a number of places where class members were being declared in the constructor and assigned to constant values that could easily be moved up into the class definition itself - when I converted everything to classes from prototypes, I just used the automatic refactor in VS Code, which wasn't smart enough to extract these. This PR moves them to the class definition and deals with the fallout of TypeScript being able to better-understand their types now.

It also goes around and removes the old `that = this` workaround that was popular before arrow functions allowed scope capture for callbacks and replaces those classic functions with arrow functions.

<!-- Link relevant GitHub issues -->
