### PR TITLE
Split `publish` NPM hook into `prepublishOnly` and `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "doc": "jsdoc -r -c jsdoc_conf.json -d ./doc .",
     "lint": "eslint .",
     "test": "vitest",
-    "publish": "npm run build && npm run test"
+    "prepublishOnly": "npm run test",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Closes #714. Currently, installing this package via Git triggers some unwanted lifecycle hooks. This makes `npm` or `pnpm` `install roslib@github:RobotWebTools/roslibjs#develop` work.

<!-- Link relevant GitHub issues -->
