### PR TITLE
Fix xmldom compatibility

### DIFF
--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -21,7 +21,7 @@ export default class UrdfModel {
   joints = {};
   /**
    * @param {Object} options
-   * @param {Element} [options.xml] - The XML element to parse.
+   * @param {Element | null} [options.xml] - The XML element to parse.
    * @param {string} [options.string] - The XML element to parse as a string.
    */
   constructor(options) {


### PR DESCRIPTION
**Public API Changes**
Extend element typing


**Description**
Element can also be null since `@xmldom/xmldom@0.9.2` (See https://github.com/xmldom/xmldom/pull/721) 


Fixes https://github.com/RobotWebTools/roslibjs/issues/778
