### PR TITLE
Add optional timeout argument to callService

### DIFF
--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -73,12 +73,9 @@ export default class Service extends EventEmitter {
       id: serviceCallId,
       service: this.name,
       type: this.serviceType,
-      args: request
+      args: request,
+      timeout: timeout
     };
-
-    if (timeout !== undefined) {
-      call.timeout = timeout;
-    }
 
     this.ros.callOnConnection(call);
   }

--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -45,8 +45,10 @@ export default class Service extends EventEmitter {
    * @param {TRequest} request - The service request to send.
    * @param {callServiceCallback} [callback] - Function with the following params:
    * @param {callServiceFailedCallback} [failedCallback] - The callback function when the service call failed with params:
-   */
-  callService(request, callback, failedCallback) {
+   * @param {number} [timeout] - Optional timeout, in seconds, for the service call. A non-positive value means no timeout.
+   *                             If not provided, the rosbridge server will use its default value.
+  */
+  callService(request, callback, failedCallback, timeout) {
     if (this.isAdvertised) {
       return;
     }
@@ -73,6 +75,11 @@ export default class Service extends EventEmitter {
       type: this.serviceType,
       args: request
     };
+
+    if (timeout !== undefined) {
+      call.timeout = timeout;
+    }
+
     this.ros.callOnConnection(call);
   }
   /**


### PR DESCRIPTION
**Public API Changes**
Added optional `timeout` argument to callService.


**Description**
After RobotWebTools/rosbridge_suite#984 was merged, it is now possible to specify a timeout when calling a service. This PR exposes this functionality to roslibjs public API.
