### PR TITLE
Use relative names for rosapi services

### DIFF
--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -36,7 +36,7 @@ export default class Param {
   get(callback, failedCallback) {
     var paramClient = new Service({
       ros: this.ros,
-      name: '/rosapi/get_param',
+      name: 'rosapi/get_param',
       serviceType: 'rosapi/GetParam'
     });
 
@@ -69,7 +69,7 @@ export default class Param {
   set(value, callback, failedCallback) {
     var paramClient = new Service({
       ros: this.ros,
-      name: '/rosapi/set_param',
+      name: 'rosapi/set_param',
       serviceType: 'rosapi/SetParam'
     });
 
@@ -89,7 +89,7 @@ export default class Param {
   delete(callback, failedCallback) {
     var paramClient = new Service({
       ros: this.ros,
-      name: '/rosapi/delete_param',
+      name: 'rosapi/delete_param',
       serviceType: 'rosapi/DeleteParam'
     });
 

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -180,7 +180,7 @@ export default class Ros extends EventEmitter {
     /** @satisfies {Service<any, any>} */
     var getActionServers = new Service({
       ros: this,
-      name: '/rosapi/action_servers',
+      name: 'rosapi/action_servers',
       serviceType: 'rosapi/GetActionServers'
     });
 
@@ -220,7 +220,7 @@ export default class Ros extends EventEmitter {
   getTopics(callback, failedCallback) {
     var topicsClient = new Service({
       ros: this,
-      name: '/rosapi/topics',
+      name: 'rosapi/topics',
       serviceType: 'rosapi/Topics'
     });
 
@@ -259,7 +259,7 @@ export default class Ros extends EventEmitter {
   getTopicsForType(topicType, callback, failedCallback) {
     var topicsForTypeClient = new Service({
       ros: this,
-      name: '/rosapi/topics_for_type',
+      name: 'rosapi/topics_for_type',
       serviceType: 'rosapi/TopicsForType'
     });
 
@@ -299,7 +299,7 @@ export default class Ros extends EventEmitter {
   getServices(callback, failedCallback) {
     var servicesClient = new Service({
       ros: this,
-      name: '/rosapi/services',
+      name: 'rosapi/services',
       serviceType: 'rosapi/Services'
     });
 
@@ -338,7 +338,7 @@ export default class Ros extends EventEmitter {
   getServicesForType(serviceType, callback, failedCallback) {
     var servicesForTypeClient = new Service({
       ros: this,
-      name: '/rosapi/services_for_type',
+      name: 'rosapi/services_for_type',
       serviceType: 'rosapi/ServicesForType'
     });
 
@@ -380,7 +380,7 @@ export default class Ros extends EventEmitter {
   getServiceRequestDetails(type, callback, failedCallback) {
     var serviceTypeClient = new Service({
       ros: this,
-      name: '/rosapi/service_request_details',
+      name: 'rosapi/service_request_details',
       serviceType: 'rosapi/ServiceRequestDetails'
     });
     var request = {
@@ -422,7 +422,7 @@ export default class Ros extends EventEmitter {
     /** @satisfies {Service<{},{typedefs: string[]}>} */
     var serviceTypeClient = new Service({
       ros: this,
-      name: '/rosapi/service_response_details',
+      name: 'rosapi/service_response_details',
       serviceType: 'rosapi/ServiceResponseDetails'
     });
     var request = {
@@ -462,7 +462,7 @@ export default class Ros extends EventEmitter {
   getNodes(callback, failedCallback) {
     var nodesClient = new Service({
       ros: this,
-      name: '/rosapi/nodes',
+      name: 'rosapi/nodes',
       serviceType: 'rosapi/Nodes'
     });
 
@@ -522,7 +522,7 @@ export default class Ros extends EventEmitter {
   getNodeDetails(node, callback, failedCallback) {
     var nodesClient = new Service({
       ros: this,
-      name: '/rosapi/node_details',
+      name: 'rosapi/node_details',
       serviceType: 'rosapi/NodeDetails'
     });
 
@@ -563,7 +563,7 @@ export default class Ros extends EventEmitter {
   getParams(callback, failedCallback) {
     var paramsClient = new Service({
       ros: this,
-      name: '/rosapi/get_param_names',
+      name: 'rosapi/get_param_names',
       serviceType: 'rosapi/GetParamNames'
     });
     var request = {};
@@ -601,7 +601,7 @@ export default class Ros extends EventEmitter {
   getTopicType(topic, callback, failedCallback) {
     var topicTypeClient = new Service({
       ros: this,
-      name: '/rosapi/topic_type',
+      name: 'rosapi/topic_type',
       serviceType: 'rosapi/TopicType'
     });
     var request = {
@@ -642,7 +642,7 @@ export default class Ros extends EventEmitter {
   getServiceType(service, callback, failedCallback) {
     var serviceTypeClient = new Service({
       ros: this,
-      name: '/rosapi/service_type',
+      name: 'rosapi/service_type',
       serviceType: 'rosapi/ServiceType'
     });
     var request = {
@@ -683,7 +683,7 @@ export default class Ros extends EventEmitter {
   getMessageDetails(message, callback, failedCallback) {
     var messageDetailClient = new Service({
       ros: this,
-      name: '/rosapi/message_details',
+      name: 'rosapi/message_details',
       serviceType: 'rosapi/MessageDetails'
     });
     var request = {
@@ -775,7 +775,7 @@ export default class Ros extends EventEmitter {
   getTopicsAndRawTypes(callback, failedCallback) {
     var topicsAndRawTypesClient = new Service({
       ros: this,
-      name: '/rosapi/topics_and_raw_types',
+      name: 'rosapi/topics_and_raw_types',
       serviceType: 'rosapi/TopicsAndRawTypes'
     });
 


### PR DESCRIPTION
**Public API Changes**
None


**Description**
When rosbridge server is running in a namespace, we can expect rosapi services to be in the same namespace (after RobotWebTools/rosbridge_suite#992 was merged). To contact services that are in the same namespace as the rosbridge server, we can just use relative topic names (without leading slash) instead of global ones.

This will help running rosbridge in multi-robot scenarios, where each robot has its own rosbridge server and rosapi nodes running under the robot's namespace.