### PR TITLE
Update Param.js to intuitively request JSON data

### DIFF
--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -75,7 +75,7 @@ export default class Param {
 
     var request = {
       name: this.name,
-      value: JSON.stringify(value)
+      value: `\"${JSON.stringify(value)}\"`
     };
 
     paramClient.callService(request, callback, failedCallback);


### PR DESCRIPTION


**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
There is an inconvenience of having to do JSON.stringify again when setting parameters.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
If you receive a parameter with get, the data will be received as a number 0, but if you try to modify it with set, you need to JSON.stringify the value again. For example, setting it as {name:"intParam",value:0} will not work, but setting it as {name:"intParam",value:`\"0\"`} will work.

<!-- Link relevant GitHub issues -->
https://github.com/RobotWebTools/rosbridge_suite/issues/1087
It's not the same problem, but it's a similar problem.
