### PR TITLE
fixed xmlDoc type error

### DIFF
--- a/src/urdf/UrdfModel.js
+++ b/src/urdf/UrdfModel.js
@@ -32,7 +32,12 @@ export default class UrdfModel {
     if (string) {
       // Parse the string
       var parser = new DOMParser();
-      xmlDoc = parser.parseFromString(string, MIME_TYPE.XML_TEXT).documentElement;
+      var parsedDoc = parser.parseFromString(string, MIME_TYPE.XML_TEXT);
+      if (parsedDoc && parsedDoc.documentElement) {
+        xmlDoc = parsedDoc.documentElement;
+      } else {
+        throw new Error('Failed to parse URDF string');
+      }
     }
     if (!xmlDoc) {
       throw new Error('No URDF document parsed!');


### PR DESCRIPTION
fixed this error:

```
src/urdf/UrdfModel.js:35:7 - error TS2322: Type 'Element | null' is not assignable to type 'Element | null | undefined'.
  Type 'Element' is missing the following properties from type 'Element': classList, className, clientHeight, clientLeft, and 102 more.

35       xmlDoc = parser.parseFromString(string, MIME_TYPE.XML_TEXT).documentElement;
         ~~~~~~


Found 1 error in src/urdf/UrdfModel.js:35
```
Add type assertion for xmldom Element compatibility
```
// Check if we are using a string or an XML element
    if (string) {
      // Parse the string
      var parser = new DOMParser();
      var parsedDoc = parser.parseFromString(string, MIME_TYPE.XML_TEXT);
      if (parsedDoc && parsedDoc.documentElement) {
        xmlDoc = parsedDoc.documentElement;
      } else {
        throw new Error('Failed to parse URDF string');
      }
    }
    if (!xmlDoc) {
      throw new Error('No URDF document parsed!');
    }
```