### PR TITLE
Add `globalThis`-preserving Import Path

### DIFF
--- a/src/RosLib.js
+++ b/src/RosLib.js
@@ -1,28 +1,11 @@
 /**
  * @fileOverview
- * @author Russell Toris - rctoris@wpi.edu
+ * @author Jeff Hykin - jeff.hykin@gmail.com
  */
 
 /** @description Library version */
-export const REVISION = '1.4.1';
-export * from './core/index.js';
-export * from './actionlib/index.js';
-export * from './math/index.js';
-export * from './tf/index.js';
-export * from './urdf/index.js';
+export * from './index.js';
+import ROSLIB from './index.js';
 
-import * as Core from './core/index.js';
-import * as ActionLib from './actionlib/index.js';
-import * as Math from './math/index.js';
-import * as Tf from './tf/index.js';
-import * as Urdf from './urdf/index.js';
-
-// Add to global namespace for in-browser support (i.e. CDN)
-globalThis.ROSLIB = {
-  REVISION,
-  ...Core,
-  ...ActionLib,
-  ...Math,
-  ...Tf,
-  ...Urdf
-};
+// same as index.js, except add to global namespace for in-browser support (i.e. CDN)
+globalThis.ROSLIB = ROSLIB;

--- a/src/RosLib.js
+++ b/src/RosLib.js
@@ -1,6 +1,6 @@
 /**
  * @fileOverview
- * @author Jeff Hykin - jeff.hykin@gmail.com
+ * @author Russell Toris - rctoris@wpi.edu
  */
 
 /** @description Library version */

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,27 @@
+/**
+ * @fileOverview
+ * @author Russell Toris - rctoris@wpi.edu
+ */
+
+/** @description Library version */
+export const REVISION = '1.4.1';
+export * from './core/index.js';
+export * from './actionlib/index.js';
+export * from './math/index.js';
+export * from './tf/index.js';
+export * from './urdf/index.js';
+
+import * as Core from './core/index.js';
+import * as ActionLib from './actionlib/index.js';
+import * as Math from './math/index.js';
+import * as Tf from './tf/index.js';
+import * as Urdf from './urdf/index.js';
+
+export default {
+  REVISION,
+  ...Core,
+  ...ActionLib,
+  ...Math,
+  ...Tf,
+  ...Urdf
+};


### PR DESCRIPTION
**Public API Changes**
None

**Description**
This has no functional change for all existing users (ex: CDN). RosLib.js exports all the same API's as before and still sets `globalThis.ROSLIB =`.

However, for users like myself who want to avoid polluting `globalThis`, this PR provides`src/index.js`.

NOTE: to avoid code duplication
- `src/index.js` consolidates the imports
- `src/RosLib.js` re-exports everything from index.js, and then additionally sets ROSLIB