### PR TITLE
Prevent "Cannot read properties of undefined" error occur from "this.transportOptions" variable

### DIFF
--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -152,7 +152,7 @@ Ros.prototype.sendEncodedMessage = function(messageEncoded) {
  * @param {Object} message - The message to be sent.
  */
 Ros.prototype.callOnConnection = function(message) {
-  if (this.transportOptions.encoder) {
+  if (this.transportOptions && this.transportOptions.encoder) {
     this.transportOptions.encoder(message, this._sendFunc);
   } else {
     this._sendFunc(JSON.stringify(message));


### PR DESCRIPTION
**Public API Changes**
Added a conditional check to ensure `this.transportOptions` is defined before accessing its properties.

**Description**
This change addresses a runtime error encountered during subscription:
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'encoder')
    at Ros.callOnConnection [as callForSubscribeAndAdvertise] (Ros.js:155:29)
    at Topic.subscribe (Topic.js:100:8)
    at Object.fn (useListener.ts:14:21)
    at runComputation (dev.js:811:22)
    at updateComputation (dev.js:789:3)
    at runTop (dev.js:906:7)
    at runUserEffects (dev.js:1020:36)
    at dev.js:975:34
    at runUpdates (dev.js:923:17)
    at completeUpdates (dev.js:975:17)
```
The root cause appears to be that `this.transportOptions` is undefined at the time of access. While it's unclear why this variable isn't initialized in some cases, adding a guard condition should prevent the error and ensure more robust behavior.


