### PR TITLE
Remove unsafe-perm npm option

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-unsafe-perm = true


### PR DESCRIPTION
I don't think we are using this anymore, and it's a security risk.
