### PR TITLE
Ignore macOS directory metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.log
 *.tar.gz
 dist
+.DS_Store


### PR DESCRIPTION
I develop on a Mac and these keep cropping up in my diffs
