### PR TITLE
Handle rosapi param responses

### DIFF
--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -31,7 +31,7 @@ export default class Param {
    * Fetch the value of the param.
    *
    * @param {getCallback} callback - The callback function.
-   * @param {getFailedCallback} [failedCallback] - The callback function when the service call failed.
+   * @param {getFailedCallback} [failedCallback] - The callback function when the service call failed or the parameter retrieval was unsuccessful.
    */
   get(callback, failedCallback) {
     var paramClient = new Service({
@@ -68,7 +68,7 @@ export default class Param {
    *
    * @param {Object} value - The value to set param to.
    * @param {setParamCallback} [callback] - The callback function.
-   * @param {setParamFailedCallback} [failedCallback] - The callback function when the service call failed.
+   * @param {setParamFailedCallback} [failedCallback] - The callback function when the service call failed or the parameter setting was unsuccessful.
    */
   set(value, callback, failedCallback) {
     var paramClient = new Service({
@@ -98,7 +98,7 @@ export default class Param {
    * Delete this parameter on the ROS server.
    *
    * @param {setParamCallback} callback - The callback function.
-   * @param {setParamFailedCallback} [failedCallback] - The callback function when the service call failed.
+   * @param {setParamFailedCallback} [failedCallback] - The callback function when the service call failed or the parameter deletion was unsuccessful.
    */
   delete(callback, failedCallback) {
     var paramClient = new Service({

--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -40,19 +40,17 @@ export default class Param {
       serviceType: 'rosapi/GetParam'
     });
 
-    var request = {name: this.name};
+    var request = { name: this.name };
 
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful !== undefined && result.successful === false) {
-          if (failedCallback) {
-            failedCallback(result.reason);
-          }
-          return;
+        if (result.successful === false && failedCallback) {
+          failedCallback(result.reason);
+        } else {
+          var value = JSON.parse(result.value);
+          callback(value);
         }
-        var value = JSON.parse(result.value);
-        callback(value);
       },
       failedCallback
     );
@@ -87,13 +85,9 @@ export default class Param {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful !== undefined && result.successful === false) {
-          if (failedCallback) {
-            failedCallback(result.reason);
-          }
-          return;
-        }
-        if (callback) {
+        if (result.successful === false && failedCallback) {
+          failedCallback(result.reason);
+        } else if (callback) {
           callback(result);
         }
       },
@@ -120,13 +114,9 @@ export default class Param {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful !== undefined && result.successful === false) {
-          if (failedCallback) {
-            failedCallback(result.reason);
-          }
-          return;
-        }
-        if (callback) {
+        if (result.successful === false && failedCallback) {
+          failedCallback(result.reason);
+        } else if (callback) {
           callback(result);
         }
       },

--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -45,6 +45,12 @@ export default class Param {
     paramClient.callService(
       request,
       function (result) {
+        if (result.successful !== undefined && result.successful === false) {
+          if (failedCallback) {
+            failedCallback(result.reason);
+          }
+          return;
+        }
         var value = JSON.parse(result.value);
         callback(value);
       },
@@ -78,7 +84,21 @@ export default class Param {
       value: JSON.stringify(value)
     };
 
-    paramClient.callService(request, callback, failedCallback);
+    paramClient.callService(
+      request,
+      function (result) {
+        if (result.successful !== undefined && result.successful === false) {
+          if (failedCallback) {
+            failedCallback(result.reason);
+          }
+          return;
+        }
+        if (callback) {
+          callback(result);
+        }
+      },
+      failedCallback
+    );
   }
   /**
    * Delete this parameter on the ROS server.
@@ -97,6 +117,20 @@ export default class Param {
       name: this.name
     };
 
-    paramClient.callService(request, callback, failedCallback);
+    paramClient.callService(
+      request,
+      function (result) {
+        if (result.successful !== undefined && result.successful === false) {
+          if (failedCallback) {
+            failedCallback(result.reason);
+          }
+          return;
+        }
+        if (callback) {
+          callback(result);
+        }
+      },
+      failedCallback
+    );
   }
 }


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Thanks to RobotWebTools/rosbridge_suite#1001, since ROS 2 Jazzy, rosapi param services return the `successful` bool and fill the reason for failure if the operation does not succeed. 

This PR adds the logic for handling these additional fields.
