### PR TITLE
fix(ROS2TFClient): Use correct action type for ROS2 tf2_web_republisher

### DIFF
--- a/src/tf/ROS2TFClient.js
+++ b/src/tf/ROS2TFClient.js
@@ -48,7 +48,7 @@ export default class ROS2TFClient extends EventEmitter {
         this.actionClient = new Action({
             ros: options.ros,
             name: this.serverName,
-            actionType: 'tf2_web_republisher_interfaces/action/TFSubscription',
+            actionType: 'tf2_web_republisher_interfaces/TFSubscription',
         });
 
     }

--- a/src/tf/ROS2TFClient.js
+++ b/src/tf/ROS2TFClient.js
@@ -48,7 +48,7 @@ export default class ROS2TFClient extends EventEmitter {
         this.actionClient = new Action({
             ros: options.ros,
             name: this.serverName,
-            actionType: 'tf2_web_republisher_msgs/TFSubscription',
+            actionType: 'tf2_web_republisher_interfaces/action/TFSubscription',
         });
 
     }


### PR DESCRIPTION
In the ROS2 version of tf2-web-republisher, the correct Action name should be tf2_web_republisher_interfaces/action/TFSubscription. Fixing this will allow PointCloud2 to be displayed correctly on the web page. This change has been tested on ROS2 Kilted, Ubuntu 24.04 and works for me.

**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes --> 
The ROS2TFClient component currently uses a hardcoded action type (tf2_web_republisher_msgs/TFSubscription) This makes the client incompatible with standard ROS 2 tf2_web_republisher, which expect the action type to be tf2_web_republisher_interfaces/action/TFSubscription.
This commit corrects the hardcoded action type to the proper ROS 2 version. As a result, TF-dependent visualizations like PointCloud2 can now be displayed correctly on a web page when using a ROS 2 backend, resolving a critical compatibility issue.
This change has been tested and verified on ROS 2 Kilted with Ubuntu 24.04.

<!-- Link relevant GitHub issues -->
Resolves #948 
