### PR TITLE
Fixed linting errors

### DIFF
--- a/src/urdf/UrdfBox.ts
+++ b/src/urdf/UrdfBox.ts
@@ -20,7 +20,7 @@ export default class UrdfBox {
 
     // Parse the xml string
     const size: Optional<string[]> = xml.getAttribute(UrdfAttrs.Size)?.split(' ');
-    if (!size || size.length !== 3) {
+    if (size?.length !== 3) {
       return;
     }
 

--- a/src/urdf/UrdfColor.ts
+++ b/src/urdf/UrdfColor.ts
@@ -32,7 +32,7 @@ export default class UrdfColor {
   constructor({ xml }: UrdfDefaultOptions) {
     // Parse the xml string
     const rgba: Optional<string[]> = xml.getAttribute(UrdfAttrs.Rgba)?.split(' ');
-    if (!rgba || rgba.length !== 4) {
+    if (rgba?.length !== 4) {
       return;
     }
 

--- a/src/urdf/UrdfMesh.ts
+++ b/src/urdf/UrdfMesh.ts
@@ -26,7 +26,7 @@ export default class UrdfMesh {
 
     // Check for a scale
     const scale: Optional<string[]> = xml.getAttribute(UrdfAttrs.Scale)?.split(' ');
-    if (!scale || scale.length !== 3) {
+    if (scale?.length !== 3) {
       return;
     }
 

--- a/src/urdf/UrdfUtils.ts
+++ b/src/urdf/UrdfUtils.ts
@@ -7,7 +7,7 @@ export function parseUrdfOrigin(originElement: Element): Pose {
   // Check the XYZ
   const xyz: string[] | undefined = originElement.getAttribute(UrdfAttrs.Xyz)?.split(' ');
   let position: Vector3 = new Vector3();
-  if (xyz && xyz.length === 3) {
+  if (xyz?.length === 3) {
     position = new Vector3({
       x: parseFloat(xyz[0]),
       y: parseFloat(xyz[1]),
@@ -18,7 +18,7 @@ export function parseUrdfOrigin(originElement: Element): Pose {
   // Check the RPY
   const rpy = originElement.getAttribute(UrdfAttrs.Rpy)?.split(' ');
   let orientation = new Quaternion();
-  if (rpy && rpy.length === 3) {
+  if (rpy?.length === 3) {
     // Convert from RPY
     const roll = parseFloat(rpy[0]);
     const pitch = parseFloat(rpy[1]);


### PR DESCRIPTION
**Public API Changes**
None


**Description**
This PR fixes an issue with the linter during the build process. The following errors are thrown when trying to build this package.
```
/usr/local/share/.cache/yarn/v6/.tmp/daaec974064c5e8d044980d3e6858ff6.f25904a999239d9a8bb4e70561e27643b468a71d.prepare/src/urdf/UrdfBox.ts
  23:9  error  Prefer using an optional chain expression instead, as it's more concise and easier to read  @typescript-eslint/prefer-optional-chain
/usr/local/share/.cache/yarn/v6/.tmp/daaec974064c5e8d044980d3e6858ff6.f25904a999239d9a8bb4e70561e27643b468a71d.prepare/src/urdf/UrdfColor.ts
  35:9  error  Prefer using an optional chain expression instead, as it's more concise and easier to read  @typescript-eslint/prefer-optional-chain
/usr/local/share/.cache/yarn/v6/.tmp/daaec974064c5e8d044980d3e6858ff6.f25904a999239d9a8bb4e70561e27643b468a71d.prepare/src/urdf/UrdfMesh.ts
  29:9  error  Prefer using an optional chain expression instead, as it's more concise and easier to read  @typescript-eslint/prefer-optional-chain
/usr/local/share/.cache/yarn/v6/.tmp/daaec974064c5e8d044980d3e6858ff6.f25904a999239d9a8bb4e70561e27643b468a71d.prepare/src/urdf/UrdfUtils.ts
  10:7  error  Prefer using an optional chain expression instead, as it's more concise and easier to read  @typescript-eslint/prefer-optional-chain
  21:7  error  Prefer using an optional chain expression instead, as it's more concise and easier to read  @typescript-eslint/prefer-optional-chain

```

