### PR TITLE
feat: add fragment support for large messages sent by rosbridge

### DIFF
--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -30,7 +30,17 @@ export default function SocketAdapter(client) {
     decoder = client.transportOptions.decoder;
   }
 
+  /**
+   * Buffer Map for incoming message fragments
+   * @type {Map<string, {fragments: Array<string>, received: number, total: number}>}
+   */
+  const fragmentBuffer = new Map();
+
   function handleMessage(message) {
+    if (message.op === 'fragment') {
+      handleFragment(message);
+      return;
+    }
     if (message.op === 'publish') {
       client.emit(message.topic, message.msg);
     } else if (message.op === 'service_response') {
@@ -51,6 +61,46 @@ export default function SocketAdapter(client) {
       } else {
         client.emit('status', message);
       }
+    }
+  }
+
+  function handleFragment(fragment) {
+    const { id, data, num, total } = fragment;
+    if (!id || typeof num !== 'number' || typeof total !== 'number' || typeof data !== 'string') {
+      // Invalid fragment, ignore
+      return;
+    }
+    // If total is a float, use its integer part for fragment count
+    const totalInt = Math.floor(total);
+    if (!fragmentBuffer.has(id)) {
+      fragmentBuffer.set(id, { fragments: [], received: 0, total: totalInt });
+    }
+    const entry = fragmentBuffer.get(id);
+
+    if (!entry) {
+      // Should not happen, keeping TypeScript happy
+      return;
+    }
+    // Only accept fragments within the integer part of total
+    if (num < totalInt) {
+      if (typeof entry.fragments[num] === 'undefined') {
+        entry.fragments[num] = data;
+        entry.received++;
+      }
+    }
+    // If all integer fragments received, reconstruct and process
+    if (entry.received === totalInt) {
+      const fullData = entry.fragments.join('');
+      let message;
+      try {
+        message = JSON.parse(fullData);
+      } catch (e) {
+        // Failed to parse, ignore
+        fragmentBuffer.delete(id);
+        return;
+      }
+      fragmentBuffer.delete(id);
+      handleMessage(message);
     }
   }
 

--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -78,8 +78,8 @@ export default function SocketAdapter(client) {
     const entry = fragmentBuffer.get(id);
 
     if (!entry) {
-      // Should not happen, keeping TypeScript happy
-      return;
+      // Should not happen, signal error
+      throw new Error('Fragment buffer entry missing for id: ' + id);
     }
     // Only accept fragments within the integer part of total
     if (num < totalInt) {

--- a/test/SocketAdapter.test.js
+++ b/test/SocketAdapter.test.js
@@ -1,0 +1,78 @@
+import { it, describe, expect, beforeEach, vi } from 'vitest';
+import SocketAdapter from '../src/core/SocketAdapter.js';
+
+describe('SocketAdapter fragment handling', () => {
+  let client;
+  let adapter;
+
+  beforeEach(() => {
+    client = {
+      emit: vi.fn(),
+      transportOptions: {}
+    };
+    adapter = SocketAdapter(client);
+    vi.clearAllMocks();
+  });
+
+  function sendFragment(id, total, fragments) {
+    for (let i = 0; i < fragments.length; i++) {
+      adapter.onmessage({
+        data: JSON.stringify({
+          op: 'fragment',
+          id,
+          data: fragments[i],
+          num: i,
+          total
+        })
+      });
+    }
+  }
+
+  it('reassembles fragments and emits message', () => {
+    const id = 'test1';
+    const total = 3;
+    const msg = { op: 'publish', topic: 'foo', msg: { data: 42 } };
+    const json = JSON.stringify(msg);
+    const fragments = [json.slice(0, 10), json.slice(10, 20), json.slice(20)];
+    sendFragment(id, total, fragments);
+    expect(client.emit).toHaveBeenCalledWith('foo', { data: 42 });
+    expect(client.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles float total by using integer part', () => {
+    const id = 'test2';
+    const total = 2.9;
+    const msg = { op: 'publish', topic: 'bar', msg: { data: 99 } };
+    const json = JSON.stringify(msg);
+    const fragments = [json.slice(0, 10), json.slice(10)];
+    sendFragment(id, total, fragments);
+    expect(client.emit).toHaveBeenCalledWith('bar', { data: 99 });
+    expect(client.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores extra fragments beyond integer total', () => {
+    const id = 'test3';
+    const total = 2.1;
+    const msg = { op: 'publish', topic: 'baz', msg: { data: 7 } };
+    const json = JSON.stringify(msg);
+    const fragments = [json.slice(0, 10), json.slice(10), 'extra'];
+    sendFragment(id, total, fragments);
+    expect(client.emit).toHaveBeenCalledWith('baz', { data: 7 });
+    expect(client.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit if fragments are missing', () => {
+    const id = 'test4';
+    const total = 2;
+    const msg = { op: 'publish', topic: 'qux', msg: { data: 123 } };
+    const json = JSON.stringify(msg);
+    const fragments = [json.slice(0, 10)]; // missing one fragment
+    sendFragment(id, total, fragments);
+    expect(client.emit).not.toHaveBeenCalledWith('qux', { data: 123 });
+  });
+
+  it('ignores malformed fragments', () => {
+    adapter.onmessage({ data: JSON.stringify({ op: 'fragment', id: 'bad' }) });
+    expect(client.emit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Messages sent to the websocket with the op fragment are not dealt with.
This buffers the incoming fragment messages and reuses the handleMessage function.

I had a service all where the result callbacks were never triggered because the event registered with the service call id was never triggered.

<!-- Link relevant GitHub issues -->
