### PR TITLE
Fix CI to use locked dependencies

### DIFF
--- a/test/build.bash
+++ b/test/build.bash
@@ -23,7 +23,7 @@ bash examples/setup_examples.bash
 echo -e "\e[1m\e[35mrostopic list\e[0m"
 rostopic list
 echo -e "\e[1m\e[35mnpm install\e[0m"
-npm install
+npm ci
 echo -e "\e[1m\e[35mnpm run build\e[0m"
 npm run build
 echo -e "\e[1m\e[35mnpm test\e[0m"


### PR DESCRIPTION
`npm ci` installs from package-lock instead of package,
so it's idempotent and also faster.
