### PR TITLE
Further modernize class definitions

### DIFF
--- a/src/actionlib/ActionClient.js
+++ b/src/actionlib/ActionClient.js
@@ -32,15 +32,23 @@ export default class ActionClient extends EventEmitter {
    * @param {boolean} [options.omitStatus] - The flag to indicate whether to omit the status channel or not.
    * @param {boolean} [options.omitResult] - The flag to indicate whether to omit the result channel or not.
    */
-  constructor(options) {
+  constructor({
+    ros,
+    serverName,
+    actionName,
+    timeout,
+    omitFeedback,
+    omitStatus,
+    omitResult
+  }) {
     super();
-    this.ros = options.ros;
-    this.serverName = options.serverName;
-    this.actionName = options.actionName;
-    this.timeout = options.timeout;
-    this.omitFeedback = options.omitFeedback;
-    this.omitStatus = options.omitStatus;
-    this.omitResult = options.omitResult;
+    this.ros = ros;
+    this.serverName = serverName;
+    this.actionName = actionName;
+    this.timeout = timeout;
+    this.omitFeedback = omitFeedback;
+    this.omitStatus = omitStatus;
+    this.omitResult = omitResult;
 
     // create the topics associated with actionlib
     this.feedbackListener = new Topic({

--- a/src/actionlib/ActionClient.js
+++ b/src/actionlib/ActionClient.js
@@ -21,7 +21,19 @@ import { EventEmitter } from 'eventemitter3';
 export default class ActionClient extends EventEmitter {
   goals = {};
   /** flag to check if a status has been received */
-  receivedStatus = false
+  receivedStatus = false;
+  ros;
+  serverName;
+  actionName;
+  timeout;
+  omitFeedback;
+  omitStatus;
+  omitResult;
+  feedbackListener;
+  statusListener;
+  resultListener;
+  goalTopic;
+  cancelTopic;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/actionlib/ActionListener.js
+++ b/src/actionlib/ActionListener.js
@@ -19,6 +19,9 @@ import { EventEmitter } from 'eventemitter3';
  *
  */
 export default class ActionListener extends EventEmitter {
+  ros;
+  serverName;
+  actionName;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/actionlib/ActionListener.js
+++ b/src/actionlib/ActionListener.js
@@ -25,11 +25,15 @@ export default class ActionListener extends EventEmitter {
    * @param {string} options.serverName - The action server name, like '/fibonacci'.
    * @param {string} options.actionName - The action message name, like 'actionlib_tutorials/FibonacciAction'.
    */
-  constructor(options) {
+  constructor({
+    ros,
+    serverName,
+    actionName
+  }) {
     super();
-    this.ros = options.ros;
-    this.serverName = options.serverName;
-    this.actionName = options.actionName;
+    this.ros = ros;
+    this.serverName = serverName;
+    this.actionName = actionName;
 
     // create the topics associated with actionlib
     var goalListener = new Topic({

--- a/src/actionlib/Goal.js
+++ b/src/actionlib/Goal.js
@@ -25,9 +25,12 @@ export default class Goal extends EventEmitter {
    * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.
    * @param {Object} options.goalMessage - The JSON object containing the goal for the action server.
    */
-  constructor(options) {
+  constructor({
+    actionClient,
+    goalMessage
+  }) {
     super();
-    this.actionClient = options.actionClient;
+    this.actionClient = actionClient;
 
     // Fill in the goal message
     this.goalMessage = {
@@ -38,7 +41,7 @@ export default class Goal extends EventEmitter {
         },
         id: this.goalID
       },
-      goal: options.goalMessage
+      goal: goalMessage
     };
 
     this.on('status', (status) => {

--- a/src/actionlib/Goal.js
+++ b/src/actionlib/Goal.js
@@ -20,6 +20,8 @@ export default class Goal extends EventEmitter {
   feedback = undefined;
   // Create a random ID
   goalID = 'goal_' + Math.random() + '_' + new Date().getTime();
+  actionClient;
+  goalMessage;
   /**
    * @param {Object} options
    * @param {ActionClient} options.actionClient - The ROSLIB.ActionClient to use with this goal.

--- a/src/actionlib/SimpleActionServer.js
+++ b/src/actionlib/SimpleActionServer.js
@@ -26,11 +26,15 @@ export default class SimpleActionServer extends EventEmitter {
    * @param {string} options.serverName - The action server name, like '/fibonacci'.
    * @param {string} options.actionName - The action message name, like 'actionlib_tutorials/FibonacciAction'.
    */
-  constructor(options) {
+  constructor({
+    ros,
+    serverName,
+    actionName
+  }) {
     super();
-    this.ros = options.ros;
-    this.serverName = options.serverName;
-    this.actionName = options.actionName;
+    this.ros = ros;
+    this.serverName = serverName;
+    this.actionName = actionName;
 
     // create and advertise publishers
     this.feedbackPublisher = new Topic({

--- a/src/actionlib/SimpleActionServer.js
+++ b/src/actionlib/SimpleActionServer.js
@@ -20,6 +20,15 @@ export default class SimpleActionServer extends EventEmitter {
   currentGoal = null; // currently tracked goal
   /** @type {{goal_id: {id: any, stamp: any}, goal: any} | null} */
   nextGoal = null; // the one this'll be preempting
+  ros;
+  serverName;
+  actionName;
+  feedbackPublisher;
+  resultPublisher;
+  statusPublisher;
+  statusMessage;
+  goalSubscriber;
+  cancelSubscriber;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/core/Action.js
+++ b/src/core/Action.js
@@ -32,6 +32,9 @@ export default class Action extends EventEmitter {
    * @type {advertiseCancelCallback | null}
    */
   _cancelCallback = null;
+  ros;
+  name;
+  actionType;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/core/Action.js
+++ b/src/core/Action.js
@@ -38,11 +38,15 @@ export default class Action extends EventEmitter {
    * @param {string} options.name - The action name, like '/fibonacci'.
    * @param {string} options.actionType - The action type, like 'example_interfaces/Fibonacci'.
    */
-  constructor(options) {
+  constructor({
+    ros,
+    name,
+    actionType
+  }) {
     super();
-    this.ros = options.ros;
-    this.name = options.name;
-    this.actionType = options.actionType;
+    this.ros = ros;
+    this.name = name;
+    this.actionType = actionType;
   }
 
   /**

--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -10,6 +10,8 @@ import Ros from '../core/Ros.js';
  * A ROS parameter.
  */
 export default class Param {
+  ros;
+  name;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -15,9 +15,12 @@ export default class Param {
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.
    * @param {string} options.name - The param name, like max_vel_x.
    */
-  constructor(options) {
-    this.ros = options.ros;
-    this.name = options.name;
+  constructor({
+    ros,
+    name
+  }) {
+    this.ros = ros;
+    this.name = name;
   }
   /**
    * @callback getCallback

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -28,7 +28,6 @@ export default class Ros extends EventEmitter {
   socket = null;
   idCounter = 0;
   isConnected = false;
-  groovyCompatibility = true;
   /**
    * @param {Object} [options]
    * @param {string} [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.
@@ -36,16 +35,21 @@ export default class Ros extends EventEmitter {
    * @param {'websocket'|RTCPeerConnection} [options.transportLibrary='websocket'] - 'websocket', or an RTCPeerConnection instance controlling how the connection is created in `connect`.
    * @param {Object} [options.transportOptions={}] - The options to use when creating a connection. Currently only used if `transportLibrary` is RTCPeerConnection.
    */
-  constructor(options) {
+  constructor({
+    url,
+    transportLibrary = 'websocket',
+    transportOptions = {},
+    groovyCompatibility = true
+  } = {}) {
     super();
-    options = options || {};
-    this.transportLibrary = options.transportLibrary || 'websocket';
-    this.transportOptions = options.transportOptions || {};
-    this.groovyCompatibility = options.groovyCompatibility ?? true;
+
+    this.transportLibrary = transportLibrary;
+    this.transportOptions = transportOptions;
+    this.groovyCompatibility = groovyCompatibility;
 
     // begin by checking if a URL was given
-    if (options.url) {
-      this.connect(options.url);
+    if (url) {
+      this.connect(url);
     }
   }
   /**

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -28,6 +28,9 @@ export default class Ros extends EventEmitter {
   socket = null;
   idCounter = 0;
   isConnected = false;
+  transportLibrary;
+  transportOptions;
+  groovyCompatibility;
   /**
    * @param {Object} [options]
    * @param {string} [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.

--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -34,11 +34,15 @@ export default class Service extends EventEmitter {
    * @param {string} options.name - The service name, like '/add_two_ints'.
    * @param {string} options.serviceType - The service type, like 'rospy_tutorials/AddTwoInts'.
    */
-  constructor(options) {
+  constructor({
+    ros,
+    name,
+    serviceType
+  }) {
     super();
-    this.ros = options.ros;
-    this.name = options.name;
-    this.serviceType = options.serviceType;
+    this.ros = ros;
+    this.name = name;
+    this.serviceType = serviceType;
   }
   /**
    * @callback callServiceCallback

--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -28,6 +28,9 @@ export default class Service extends EventEmitter {
    * @private
    */
   _pendingUnadvertise = false;
+  ros;
+  name;
+  serviceType;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -21,6 +21,15 @@ export default class Topic extends EventEmitter {
   /** @type {(() => void) | undefined} */
   reconnectFunc = undefined;
   isAdvertised = false;
+  ros;
+  name;
+  messageType;
+  compression;
+  throttle_rate;
+  latch;
+  queue_size;
+  queue_length;
+  reconnect_on_close;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -33,20 +33,28 @@ export default class Topic extends EventEmitter {
    * @param {number} [options.queue_length=0] - The queue length at bridge side used when subscribing.
    * @param {boolean} [options.reconnect_on_close=true] - The flag to enable resubscription and readvertisement on close event.
    */
-  constructor(options) {
+  constructor({
+    ros,
+    name,
+    messageType,
+    compression = 'none',
+    throttle_rate = 0,
+    latch = false,
+    queue_size = 100,
+    queue_length = 0,
+    reconnect_on_close = true
+  }) {
     super();
-    this.ros = options.ros;
-    this.name = options.name;
-    this.messageType = options.messageType;
-    this.compression = options.compression || 'none';
-    this.throttle_rate = options.throttle_rate || 0;
-    this.latch = options.latch || false;
-    this.queue_size = options.queue_size || 100;
-    this.queue_length = options.queue_length || 0;
-    this.reconnect_on_close =
-      options.reconnect_on_close !== undefined
-        ? options.reconnect_on_close
-        : true;
+
+    this.ros = ros;
+    this.name = name;
+    this.messageType = messageType;
+    this.compression = compression;
+    this.throttle_rate = throttle_rate;
+    this.latch = latch;
+    this.queue_size = queue_size;
+    this.queue_length = queue_length;
+    this.reconnect_on_close = reconnect_on_close;
 
     // Check for valid compression types
     if (
@@ -59,7 +67,7 @@ export default class Topic extends EventEmitter {
       this.emit(
         'warning',
         this.compression +
-          ' compression is not supported. No compression will be used.'
+        ' compression is not supported. No compression will be used.'
       );
       this.compression = 'none';
     }

--- a/src/tf/ROS2TFClient.js
+++ b/src/tf/ROS2TFClient.js
@@ -9,6 +9,21 @@ import { EventEmitter } from 'eventemitter3';
  * A TF Client that listens to TFs from tf2_web_republisher.
  */
 export default class ROS2TFClient extends EventEmitter {
+  ros;
+  fixedFrame;
+  angularThres;
+  transThres;
+  rate;
+  updateDelay;
+  topicTimeout;
+  serverName;
+  goal_id;
+  frameInfos;
+  republisherUpdateRequested;
+  _subscribeCB;
+  _isDisposed;
+  actionClient;
+  currentGoal;
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.

--- a/src/tf/ROS2TFClient.js
+++ b/src/tf/ROS2TFClient.js
@@ -3,7 +3,7 @@ import Action from '../core/Action.js';
 import Transform from '../math/Transform.js';
 
 import Ros from '../core/Ros.js';
-import {EventEmitter} from 'eventemitter3';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * A TF Client that listens to TFs from tf2_web_republisher.
@@ -22,22 +22,32 @@ export default class ROS2TFClient extends EventEmitter {
    * @param {string} [options.serverName="/tf2_web_republisher"] - The name of the tf2_web_republisher server.
    * @param {string} [options.repubServiceName="/republish_tfs"] - The name of the republish_tfs service (non groovy compatibility mode only).
    */
-  constructor(options) {
+  constructor({
+    ros,
+    fixedFrame = 'base_link',
+    angularThres = 2.0,
+    transThres = 0.01,
+    rate = 10.0,
+    updateDelay = 50,
+    topicTimeout = 2.0,
+    serverName = '/tf2_web_republisher'
+  }) {
     super();
-    this.ros = options.ros;
-    this.fixedFrame = options.fixedFrame || 'base_link';
-    this.angularThres = options.angularThres || 2.0;
-    this.transThres = options.transThres || 0.01;
-    this.rate = options.rate || 10.0;
-    this.updateDelay = options.updateDelay || 50;
-    const seconds = options.topicTimeout || 2.0;
+
+    this.ros = ros;
+    this.fixedFrame = fixedFrame;
+    this.angularThres = angularThres;
+    this.transThres = transThres;
+    this.rate = rate;
+    this.updateDelay = updateDelay;
+    const seconds = topicTimeout;
     const secs = Math.floor(seconds);
     const nsecs = Math.floor((seconds - secs) * 1E9);
     this.topicTimeout = {
       secs: secs,
       nsecs: nsecs
     };
-    this.serverName = options.serverName || '/tf2_web_republisher';
+    this.serverName = serverName;
     this.goal_id = '';
     this.frameInfos = {};
     this.republisherUpdateRequested = false;
@@ -46,7 +56,7 @@ export default class ROS2TFClient extends EventEmitter {
 
     // Create an Action Client
     this.actionClient = new Action({
-      ros: options.ros,
+      ros: this.ros,
       name: this.serverName,
       actionType: 'tf2_web_republisher_interfaces/TFSubscription',
     });

--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -40,27 +40,38 @@ export default class TFClient extends EventEmitter {
    * @param {string} [options.serverName="/tf2_web_republisher"] - The name of the tf2_web_republisher server.
    * @param {string} [options.repubServiceName="/republish_tfs"] - The name of the republish_tfs service (non groovy compatibility mode only).
    */
-  constructor(options) {
+  constructor({
+    ros,
+    fixedFrame = 'base_link',
+    angularThres = 2.0,
+    transThres = 0.01,
+    rate = 10.0,
+    updateDelay = 50,
+    topicTimeout = 2.0,
+    serverName = '/tf2_web_republisher',
+    repubServiceName = '/republish_tfs'
+  }) {
     super();
-    this.ros = options.ros;
-    this.fixedFrame = options.fixedFrame || 'base_link';
-    this.angularThres = options.angularThres || 2.0;
-    this.transThres = options.transThres || 0.01;
-    this.rate = options.rate || 10.0;
-    this.updateDelay = options.updateDelay || 50;
-    var seconds = options.topicTimeout || 2.0;
+
+    this.ros = ros;
+    this.fixedFrame = fixedFrame;
+    this.angularThres = angularThres;
+    this.transThres = transThres;
+    this.rate = rate;
+    this.updateDelay = updateDelay;
+    var seconds = topicTimeout;
     var secs = Math.floor(seconds);
     var nsecs = Math.floor((seconds - secs) * 1000000000);
     this.topicTimeout = {
       secs: secs,
       nsecs: nsecs
     };
-    this.serverName = options.serverName || '/tf2_web_republisher';
-    this.repubServiceName = options.repubServiceName || '/republish_tfs';
+    this.serverName = serverName;
+    this.repubServiceName = repubServiceName;
 
     // Create an Action Client
     this.actionClient = new ActionClient({
-      ros: options.ros,
+      ros: this.ros,
       serverName: this.serverName,
       actionName: 'tf2_web_republisher/TFSubscriptionAction',
       omitStatus: true,
@@ -69,7 +80,7 @@ export default class TFClient extends EventEmitter {
 
     // Create a Service Client
     this.serviceClient = new Service({
-      ros: options.ros,
+      ros: this.ros,
       name: this.repubServiceName,
       serviceType: 'tf2_web_republisher/RepublishTFs'
     });
@@ -214,7 +225,7 @@ export default class TFClient extends EventEmitter {
       frameID = frameID.substring(1);
     }
     var info = this.frameInfos[frameID];
-    for (var cbs = (info && info.cbs) || [], idx = cbs.length; idx--; ) {
+    for (var cbs = (info && info.cbs) || [], idx = cbs.length; idx--;) {
       if (cbs[idx] === callback) {
         cbs.splice(idx, 1);
       }

--- a/src/tf/TFClient.js
+++ b/src/tf/TFClient.js
@@ -27,6 +27,18 @@ export default class TFClient extends EventEmitter {
   /** @type {((tf: any) => any) | undefined} */
   _subscribeCB = undefined;
   _isDisposed = false;
+  ros;
+  fixedFrame;
+  angularThres;
+  transThres;
+  rate;
+  updateDelay;
+  topicTimeout;
+  serverName;
+  repubServiceName;
+  actionClient;
+  serviceClient;
+
   /**
    * @param {Object} options
    * @param {Ros} options.ros - The ROSLIB.Ros connection handle.


### PR DESCRIPTION
Two major cleanups:

- Destructure options objects in the class constructor signature to make defaults clearer
- Add missing class member declarations for members that are assigned in the constructor but not declared. This will be required when moving to TypeScript and has made the type inference better when working in the JS code in the meantime.

## This is not a breaking change, it just changes some syntactic sugar and explicitly declares some things that were previously implicitly declared!