### PR TITLE
Add protocol type validation

### DIFF
--- a/src/core/Action.js
+++ b/src/core/Action.js
@@ -5,6 +5,7 @@
 
 import { EventEmitter } from 'eventemitter3';
 import { GoalStatus } from '../core/GoalStatus.ts';
+import { isRosbridgeActionFeedbackMessage, isRosbridgeActionResultMessage, isRosbridgeCancelActionGoalMessage } from '../types/protocol.ts';
 
 /**
  * A ROS 2 action client.
@@ -88,14 +89,16 @@ export default class Action extends EventEmitter {
             failedCallback(message.values);
           }
         } else if (
-          message.op === 'action_feedback' &&
+          isRosbridgeActionFeedbackMessage(message) &&
           typeof feedbackCallback === 'function'
         ) {
+          // @ts-expect-error -- can't do generic type guards in this file until it's migrated to typescript
           feedbackCallback(message.values);
         } else if (
-          message.op === 'action_result' &&
+          isRosbridgeActionResultMessage(message) &&
           typeof resultCallback === 'function'
         ) {
+          // @ts-expect-error -- can't do generic type guards in this file until it's migrated to typescript
           resultCallback(message.values);
         }
       });
@@ -181,7 +184,7 @@ export default class Action extends EventEmitter {
     if (typeof id === 'string') {
       this.ros.on(id, (message) => {
         if (
-          message.op === 'cancel_action_goal' &&
+          isRosbridgeCancelActionGoalMessage(message) &&
           typeof this._cancelCallback === 'function'
         ) {
           this._cancelCallback(id);

--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -126,7 +126,7 @@ export default class Ros extends EventEmitter {
   /**
    * Send an encoded message over the WebSocket.
    *
-   * @param {Object} messageEncoded - The encoded message to be sent.
+   * @param {string} messageEncoded - The encoded message to be sent.
    */
   sendEncodedMessage(messageEncoded) {
     if (!this.isConnected) {
@@ -145,7 +145,8 @@ export default class Ros extends EventEmitter {
    * Send the message over the WebSocket, but queue the message up if not yet
    * connected.
    *
-   * @param {Object} message - The message to be sent.
+   * @template {import('../types/protocol.ts').RosbridgeMessage} TMessage
+   * @param {TMessage} message - The message to be sent.
    */
   callOnConnection(message) {
     if (this.transportOptions.encoder) {

--- a/src/core/Service.js
+++ b/src/core/Service.js
@@ -213,7 +213,7 @@ export default class Service extends EventEmitter {
       }
 
       this._serviceCallback = async (rosbridgeRequest) => {
-        /** @type {{op: string, service: string, values?: TResponse, result: boolean, id?: string}} */
+        /** @type {import('../types/protocol.ts').RosbridgeServiceResponseMessage<TResponse>} */
         const rosbridgeResponse = {
           op: 'service_response',
           service: this.name,

--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -9,6 +9,7 @@
 
 import CBOR from 'cbor-js';
 import typedArrayTagger from '../util/cborTypedArrayTags.js';
+import { isRosbridgeActionFeedbackMessage, isRosbridgeActionResultMessage, isRosbridgeCallServiceMessage, isRosbridgeCancelActionGoalMessage, isRosbridgeFragmentMessage, isRosbridgePngMessage, isRosbridgePublishMessage, isRosbridgeSendActionGoalMessage, isRosbridgeServiceResponseMessage, isRosbridgeStatusMessage } from '../types/protocol.js';
 let BSON = null;
 // @ts-expect-error -- Workarounds for not including BSON in bundle. need to revisit
 if (typeof bson !== 'undefined') {
@@ -23,6 +24,7 @@ if (typeof bson !== 'undefined') {
  *
  * @namespace SocketAdapter
  * @private
+ * @param {import('./Ros.js').default} client
  */
 export default function SocketAdapter(client) {
   let decoder = null;
@@ -36,26 +38,31 @@ export default function SocketAdapter(client) {
    */
   const fragmentBuffer = new Map();
 
+  /**
+   * @param {import('../types/protocol.ts').RosbridgeMessage} message
+   */
   function handleMessage(message) {
-    if (message.op === 'fragment') {
+    if (isRosbridgeFragmentMessage(message)) {
       handleFragment(message);
-      return;
-    }
-    if (message.op === 'publish') {
+    } else if (isRosbridgePublishMessage(message)) {
       client.emit(message.topic, message.msg);
-    } else if (message.op === 'service_response') {
-      client.emit(message.id, message);
-    } else if (message.op === 'call_service') {
+    } else if (isRosbridgeServiceResponseMessage(message)) {
+      if (message.id) {
+        client.emit(message.id, message);
+      } else {
+        console.error('Received service response without ID');
+      }
+    } else if (isRosbridgeCallServiceMessage(message)) {
       client.emit(message.service, message);
-    } else if (message.op === 'send_action_goal') {
+    } else if (isRosbridgeSendActionGoalMessage(message)) {
       client.emit(message.action, message);
-    } else if (message.op === 'cancel_action_goal') {
+    } else if (isRosbridgeCancelActionGoalMessage(message)) {
       client.emit(message.id, message);
-    } else if (message.op === 'action_feedback') {
+    } else if (isRosbridgeActionFeedbackMessage(message)) {
       client.emit(message.id, message);
-    } else if (message.op === 'action_result') {
+    } else if (isRosbridgeActionResultMessage(message)) {
       client.emit(message.id, message);
-    } else if (message.op === 'status') {
+    } else if (isRosbridgeStatusMessage(message)) {
       if (message.id) {
         client.emit('status:' + message.id, message);
       } else {
@@ -64,6 +71,9 @@ export default function SocketAdapter(client) {
     }
   }
 
+  /**
+   * @param {import('../types/protocol.ts').RosbridgeFragmentMessage} fragment
+   */
   function handleFragment(fragment) {
     const { id, data, num, total } = fragment;
     if (!id || typeof num !== 'number' || typeof total !== 'number' || typeof data !== 'string') {
@@ -104,14 +114,18 @@ export default function SocketAdapter(client) {
     }
   }
 
+  /**
+   * @param {import('../types/protocol.ts').RosbridgeMessage} message
+   * @param {(message: import('../types/protocol.ts').RosbridgeMessage) => void} callback
+   */
   function handlePng(message, callback) {
-    if (message.op === 'png') {
+    if (isRosbridgePngMessage(message)) {
       // If in Node.js..
       if (typeof window === 'undefined') {
         import('../util/decompressPng.js').then(({ default: decompressPng }) => { decompressPng(message.data, callback); });
       } else {
         // if in browser..
-        import('../util/shim/decompressPng.js').then(({default: decompressPng}) => { decompressPng(message.data, callback); });
+        import('../util/shim/decompressPng.js').then(({ default: decompressPng }) => { decompressPng(message.data, callback); });
       }
     } else {
       callback(message);

--- a/src/core/Topic.js
+++ b/src/core/Topic.js
@@ -29,6 +29,8 @@ export default class Topic extends EventEmitter {
   queue_size;
   queue_length;
   reconnect_on_close;
+  /** @type {(message: import('../types/protocol.ts').RosbridgeSubscribeMessage | import('../types/protocol.ts').RosbridgeAdvertiseMessage) => void}*/
+  callForSubscribeAndAdvertise;
   /**
    * @param {Object} options
    * @param {import('./Ros.js').default} options.ros - The ROSLIB.Ros connection handle.

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -10,12 +10,24 @@ export interface RosbridgeFragmentMessage extends RosbridgeMessage {
   total: number;
 }
 
+export function isRosbridgeFragmentMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeFragmentMessage {
+  return message.op === 'fragment';
+}
+
 export interface RosbridgePngMessage extends RosbridgeMessage {
   op: 'png';
   id?: string;
   data: string;
   num?: number;
   total?: number;
+}
+
+export function isRosbridgePngMessage(
+  message: RosbridgeMessage,
+): message is RosbridgePngMessage {
+  return message.op === 'png';
 }
 
 export interface RosbridgeAdvertiseMessage extends RosbridgeMessage {
@@ -25,10 +37,22 @@ export interface RosbridgeAdvertiseMessage extends RosbridgeMessage {
   topic: string;
 }
 
+export function isRosbridgeAdvertiseMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeAdvertiseMessage {
+  return message.op === 'advertise';
+}
+
 export interface RosbridgeUnadvertiseMessage extends RosbridgeMessage {
   op: 'unadvertise';
   id?: string;
   topic: string;
+}
+
+export function isRosbridgeUnadvertiseMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeUnadvertiseMessage {
+  return message.op === 'unadvertise';
 }
 
 export interface RosbridgePublishMessage<TMessage = unknown>
@@ -37,6 +61,12 @@ export interface RosbridgePublishMessage<TMessage = unknown>
   id?: string;
   topic: string;
   msg: TMessage;
+}
+
+export function isRosbridgePublishMessage(
+  message: RosbridgeMessage,
+): message is RosbridgePublishMessage {
+  return message.op === 'publish';
 }
 
 export interface RosbridgeSubscribeMessage extends RosbridgeMessage {
@@ -50,10 +80,22 @@ export interface RosbridgeSubscribeMessage extends RosbridgeMessage {
   compression?: string;
 }
 
+export function isRosbridgeSubscribeMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeSubscribeMessage {
+  return message.op === 'subscribe';
+}
+
 export interface RosbridgeUnsubscribeMessage extends RosbridgeMessage {
   op: 'unsubscribe';
   id?: string;
   topic: string;
+}
+
+export function isRosbridgeUnsubscribeMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeUnsubscribeMessage {
+  return message.op === 'unsubscribe';
 }
 
 export interface RosbridgeAdvertiseServiceMessage extends RosbridgeMessage {
@@ -62,9 +104,21 @@ export interface RosbridgeAdvertiseServiceMessage extends RosbridgeMessage {
   service: string;
 }
 
+export function isRosbridgeAdvertiseServiceMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeAdvertiseServiceMessage {
+  return message.op === 'advertise_service';
+}
+
 export interface RosbridgeUnadvertiseServiceMessage extends RosbridgeMessage {
   op: 'unadvertise_service';
   service: string;
+}
+
+export function isRosbridgeUnadvertiseServiceMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeUnadvertiseServiceMessage {
+  return message.op === 'unadvertise_service';
 }
 
 export interface RosbridgeCallServiceMessage<TArgs = unknown[]>
@@ -78,6 +132,12 @@ export interface RosbridgeCallServiceMessage<TArgs = unknown[]>
   timeout?: number;
 }
 
+export function isRosbridgeCallServiceMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeCallServiceMessage {
+  return message.op === 'call_service';
+}
+
 export interface RosbridgeServiceResponseMessage<TValues = unknown[]>
   extends RosbridgeMessage {
   op: 'service_response';
@@ -87,15 +147,33 @@ export interface RosbridgeServiceResponseMessage<TValues = unknown[]>
   result: boolean;
 }
 
+export function isRosbridgeServiceResponseMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeServiceResponseMessage {
+  return message.op === 'service_response';
+}
+
 export interface RosbridgeAdvertiseActionMessage extends RosbridgeMessage {
   op: 'advertise_action';
   type: string;
   action: string;
 }
 
+export function isRosbridgeAdvertiseActionMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeAdvertiseActionMessage {
+  return message.op === 'advertise_action';
+}
+
 export interface RosbridgeUnadvertiseActionMessage extends RosbridgeMessage {
   op: 'unadvertise_action';
   action: string;
+}
+
+export function isRosbridgeUnadvertiseActionMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeUnadvertiseActionMessage {
+  return message.op === 'unadvertise_action';
 }
 
 export interface RosbridgeSendActionGoalMessage<TArgs = unknown[]>
@@ -110,13 +188,25 @@ export interface RosbridgeSendActionGoalMessage<TArgs = unknown[]>
   compression?: string;
 }
 
+export function isRosbridgeSendActionGoalMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeSendActionGoalMessage {
+  return message.op === 'send_action_goal';
+}
+
 export interface RosbridgeCancelActionGoalMessage extends RosbridgeMessage {
   op: 'cancel_action_goal';
   id: string;
   action: string;
 }
 
-export interface RosbridgeActionFeedbackMessage<TFeedback>
+export function isRosbridgeCancelActionGoalMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeCancelActionGoalMessage {
+  return message.op === 'cancel_action_goal';
+}
+
+export interface RosbridgeActionFeedbackMessage<TFeedback = unknown>
   extends RosbridgeMessage {
   op: 'action_feedback';
   id: string;
@@ -124,7 +214,13 @@ export interface RosbridgeActionFeedbackMessage<TFeedback>
   values: TFeedback;
 }
 
-export interface RosbridgeActionResultMessage<TResultValues>
+export function isRosbridgeActionFeedbackMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeActionFeedbackMessage {
+  return message.op === 'action_feedback';
+}
+
+export interface RosbridgeActionResultMessage<TResultValues = unknown>
   extends RosbridgeMessage {
   op: 'action_result';
   id: string;
@@ -132,4 +228,23 @@ export interface RosbridgeActionResultMessage<TResultValues>
   values: TResultValues;
   status: number;
   result: boolean;
+}
+
+export function isRosbridgeActionResultMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeActionResultMessage {
+  return message.op === 'action_result';
+}
+
+export interface RosbridgeActionStatusMessage extends RosbridgeMessage {
+  op: 'action_status';
+  id: string;
+  action: string;
+  status: number;
+}
+
+export function isRosbridgeActionStatusMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeActionStatusMessage {
+  return message.op === 'action_status';
 }

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,0 +1,135 @@
+interface RosbridgeMessage {
+  op: string;
+}
+
+export interface RosbridgeFragmentMessage extends RosbridgeMessage {
+  op: 'fragment';
+  id: string;
+  data: string;
+  num: number;
+  total: number;
+}
+
+export interface RosbridgePngMessage extends RosbridgeMessage {
+  op: 'png';
+  id?: string;
+  data: string;
+  num?: number;
+  total?: number;
+}
+
+export interface RosbridgeAdvertiseMessage extends RosbridgeMessage {
+  op: 'advertise';
+  id?: string;
+  type: string;
+  topic: string;
+}
+
+export interface RosbridgeUnadvertiseMessage extends RosbridgeMessage {
+  op: 'unadvertise';
+  id?: string;
+  topic: string;
+}
+
+export interface RosbridgePublishMessage<TMessage = unknown>
+  extends RosbridgeMessage {
+  op: 'publish';
+  id?: string;
+  topic: string;
+  msg: TMessage;
+}
+
+export interface RosbridgeSubscribeMessage extends RosbridgeMessage {
+  op: 'subscribe';
+  id?: string;
+  topic: string;
+  type?: string;
+  throttle_rate?: number;
+  queue_length?: number;
+  fragment_size?: number;
+  compression?: string;
+}
+
+export interface RosbridgeUnsubscribeMessage extends RosbridgeMessage {
+  op: 'unsubscribe';
+  id?: string;
+  topic: string;
+}
+
+export interface RosbridgeAdvertiseServiceMessage extends RosbridgeMessage {
+  op: 'advertise_service';
+  type: string;
+  service: string;
+}
+
+export interface RosbridgeUnadvertiseServiceMessage extends RosbridgeMessage {
+  op: 'unadvertise_service';
+  service: string;
+}
+
+export interface RosbridgeCallServiceMessage<TArgs = unknown[]>
+  extends RosbridgeMessage {
+  op: 'call_service';
+  id?: string;
+  service: string;
+  args?: TArgs;
+  fragment_size?: number;
+  compression?: string;
+  timeout?: number;
+}
+
+export interface RosbridgeServiceResponseMessage<TValues = unknown[]>
+  extends RosbridgeMessage {
+  op: 'service_response';
+  id?: string;
+  service: string;
+  values?: TValues;
+  result: boolean;
+}
+
+export interface RosbridgeAdvertiseActionMessage extends RosbridgeMessage {
+  op: 'advertise_action';
+  type: string;
+  action: string;
+}
+
+export interface RosbridgeUnadvertiseActionMessage extends RosbridgeMessage {
+  op: 'unadvertise_action';
+  action: string;
+}
+
+export interface RosbridgeSendActionGoalMessage<TArgs = unknown[]>
+  extends RosbridgeMessage {
+  op: 'send_action_goal';
+  id?: string;
+  action: string;
+  action_type: string;
+  args?: TArgs;
+  feedback?: boolean;
+  fragment_size?: number;
+  compression?: string;
+}
+
+export interface RosbridgeCancelActionGoalMessage extends RosbridgeMessage {
+  op: 'cancel_action_goal';
+  id: string;
+  action: string;
+}
+
+export interface RosbridgeActionFeedbackMessage<TFeedback>
+  extends RosbridgeMessage {
+  op: 'action_feedback';
+  id: string;
+  action: string;
+  values: TFeedback;
+}
+
+export interface RosbridgeActionResultMessage<TResultValues>
+  extends RosbridgeMessage {
+  op: 'action_result';
+  id: string;
+  action: string;
+  values: TResultValues;
+  status: number;
+  result: boolean;
+}

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,5 +1,18 @@
-interface RosbridgeMessage {
+export interface RosbridgeMessage {
   op: string;
+}
+
+export interface RosbridgeStatusMessage extends RosbridgeMessage {
+  op: 'status';
+  id?: string;
+  level: string;
+  msg: string;
+}
+
+export function isRosbridgeStatusMessage(
+  message: RosbridgeMessage,
+): message is RosbridgeStatusMessage {
+  return message.op === 'status';
 }
 
 export interface RosbridgeFragmentMessage extends RosbridgeMessage {
@@ -35,6 +48,8 @@ export interface RosbridgeAdvertiseMessage extends RosbridgeMessage {
   id?: string;
   type: string;
   topic: string;
+  latch?: boolean;
+  queue_size?: number;
 }
 
 export function isRosbridgeAdvertiseMessage(
@@ -176,7 +191,7 @@ export function isRosbridgeUnadvertiseActionMessage(
   return message.op === 'unadvertise_action';
 }
 
-export interface RosbridgeSendActionGoalMessage<TArgs = unknown[]>
+export interface RosbridgeSendActionGoalMessage<TArgs = unknown>
   extends RosbridgeMessage {
   op: 'send_action_goal';
   id?: string;
@@ -214,9 +229,9 @@ export interface RosbridgeActionFeedbackMessage<TFeedback = unknown>
   values: TFeedback;
 }
 
-export function isRosbridgeActionFeedbackMessage(
+export function isRosbridgeActionFeedbackMessage<TFeedback = unknown>(
   message: RosbridgeMessage,
-): message is RosbridgeActionFeedbackMessage {
+): message is RosbridgeActionFeedbackMessage<TFeedback> {
   return message.op === 'action_feedback';
 }
 


### PR DESCRIPTION
Added TypeScript interfaces for the whole rosbridge protocol (as documented in the markdown file in rosbridge - maybe we should make a proper JSON schema that can be interpreted into types in our various languages), added type guards that mark an object as the right type dependent on its `op` field, and used those type guards in the (most important) places where messages are directly interacted with.