### PR TITLE
Refactor SocketAdapter from mixin pattern to a wrapper

### DIFF
--- a/src/core/Ros.js
+++ b/src/core/Ros.js
@@ -4,6 +4,16 @@
  */
 
 import socketAdapter from "./SocketAdapter.js";
+import {
+  isRosbridgeActionFeedbackMessage,
+  isRosbridgeActionResultMessage,
+  isRosbridgeCallServiceMessage,
+  isRosbridgeCancelActionGoalMessage,
+  isRosbridgePublishMessage,
+  isRosbridgeSendActionGoalMessage,
+  isRosbridgeServiceResponseMessage,
+  isRosbridgeStatusMessage,
+} from "../types/protocol.js";
 
 import Topic from "./Topic.js";
 import Service from "./Service.js";
@@ -24,7 +34,7 @@ import { EventEmitter } from "eventemitter3";
  *  * &#60;serviceID&#62; - A service response came from rosbridge with the given ID.
  */
 export default class Ros extends EventEmitter {
-  /** @type {WebSocket | import("ws").WebSocket | null} */
+  /** @type {import('./SocketAdapter.js').default | null} */
   socket = null;
   idCounter = 0;
   isConnected = false;
@@ -56,37 +66,102 @@ export default class Ros extends EventEmitter {
     }
   }
   /**
-   * Connect to the specified WebSocket.
-   *
+   * Create the appropriate transport based on transport library configuration
    * @param {string} url - WebSocket URL or RTCDataChannel label for rosbridge.
+   * @returns {Promise<WebSocket|RTCDataChannel|import("ws").WebSocket|null>} The created transport
+   * @private
    */
-  connect(url) {
+  async createTransport(url) {
     if (this.transportLibrary.constructor.name === "RTCPeerConnection") {
-      this.socket = Object.assign(
-        // @ts-expect-error -- this is kinda wild. `this.transportLibrary` can either be a string or an RTCDataChannel. This needs fixing.
-        this.transportLibrary.createDataChannel(url, this.transportOptions),
-        socketAdapter(this),
+      // @ts-expect-error -- this is kinda wild. `this.transportLibrary` can either be a string or an RTCDataChannel. This needs fixing.
+      const dataChannel = this.transportLibrary.createDataChannel(
+        url,
+        this.transportOptions,
       );
+      return dataChannel;
     } else if (this.transportLibrary === "websocket") {
       // browsers, Deno, and Bun support WebSockets natively
       if (typeof WebSocket === "function") {
         if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
           const sock = new WebSocket(url);
           sock.binaryType = "arraybuffer";
-          this.socket = Object.assign(sock, socketAdapter(this));
+          return sock;
         }
+        return null; // Already connected
       } else {
         // if in Node.js, import ws to replace WebSocket API
-        import("ws").then((ws) => {
-          if (!this.socket || this.socket.readyState === ws.WebSocket.CLOSED) {
-            const sock = new ws.WebSocket(url);
-            sock.binaryType = "arraybuffer";
-            this.socket = Object.assign(sock, socketAdapter(this));
-          }
-        });
+        const ws = await import("ws");
+        if (!this.socket || this.socket.readyState === ws.WebSocket.CLOSED) {
+          const sock = new ws.WebSocket(url);
+          sock.binaryType = "arraybuffer";
+          return sock;
+        }
+        return null; // Already connected
       }
     } else {
       throw "Unknown transportLibrary: " + this.transportLibrary.toString();
+    }
+  }
+
+  /**
+   * @param {string} url - WebSocket URL or RTCDataChannel label for rosbridge.
+   */
+  async connect(url) {
+    const transport = await this.createTransport(url);
+
+    if (!transport) {
+      return; // Already connected
+    }
+
+    this.socket = new socketAdapter(transport, {
+      onOpen: (event) => {
+        this.isConnected = true;
+        this.emit("connection", event);
+      },
+      onClose: (event) => {
+        this.isConnected = false;
+        this.emit("close", event);
+      },
+      onError: (event) => {
+        this.emit("error", event);
+      },
+      onMessage: (message) => {
+        this.handleMessage(message);
+      },
+      decoder: this.transportOptions.decoder,
+    });
+  }
+
+  /**
+   * Handle processed messages from SocketAdapter
+   * @param {import('../types/protocol.ts').RosbridgeMessage} message
+   * @private
+   */
+  handleMessage(message) {
+    if (isRosbridgePublishMessage(message)) {
+      this.emit(message.topic, message.msg);
+    } else if (isRosbridgeServiceResponseMessage(message)) {
+      if (message.id) {
+        this.emit(message.id, message);
+      } else {
+        console.error("Received service response without ID");
+      }
+    } else if (isRosbridgeCallServiceMessage(message)) {
+      this.emit(message.service, message);
+    } else if (isRosbridgeSendActionGoalMessage(message)) {
+      this.emit(message.action, message);
+    } else if (isRosbridgeCancelActionGoalMessage(message)) {
+      this.emit(message.id, message);
+    } else if (isRosbridgeActionFeedbackMessage(message)) {
+      this.emit(message.id, message);
+    } else if (isRosbridgeActionResultMessage(message)) {
+      this.emit(message.id, message);
+    } else if (isRosbridgeStatusMessage(message)) {
+      if (message.id) {
+        this.emit("status:" + message.id, message);
+      } else {
+        this.emit("status", message);
+      }
     }
   }
   /**

--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -1,25 +1,8 @@
-/**
- * Socket event handling utilities for handling events on either
- * WebSocket and TCP sockets
- *
- * Note to anyone reviewing this code: these functions are called
- * in the context of their parent object, unless bound
- * @fileOverview
- */
-
 import CBOR from "cbor-js";
 import typedArrayTagger from "../util/cborTypedArrayTags.js";
 import {
-  isRosbridgeActionFeedbackMessage,
-  isRosbridgeActionResultMessage,
-  isRosbridgeCallServiceMessage,
-  isRosbridgeCancelActionGoalMessage,
   isRosbridgeFragmentMessage,
   isRosbridgePngMessage,
-  isRosbridgePublishMessage,
-  isRosbridgeSendActionGoalMessage,
-  isRosbridgeServiceResponseMessage,
-  isRosbridgeStatusMessage,
 } from "../types/protocol.js";
 let BSON = null;
 // @ts-expect-error -- Workarounds for not including BSON in bundle. need to revisit
@@ -29,63 +12,66 @@ if (typeof bson !== "undefined") {
 }
 
 /**
- * Event listeners for a WebSocket or TCP socket to a JavaScript
- * ROS Client. Sets up Messages for a given topic to trigger an
- * event on the ROS client.
+ * Socket adapter that provides unified event handling for WebSocket and RTCDataChannel.
+ * Handles transport-level concerns like fragmentation, encoding/decoding, and delegates
+ * message processing to provided callbacks.
  *
- * @namespace SocketAdapter
- * @private
- * @param {import('./Ros.js').default} client
+ * @class SocketAdapter
  */
-export default function SocketAdapter(client) {
-  let decoder = null;
-  if (client.transportOptions.decoder) {
-    decoder = client.transportOptions.decoder;
+export default class SocketAdapter {
+  /**
+   * @param {WebSocket|RTCDataChannel|import("ws").WebSocket} socket - The socket to attach event listeners to
+   * @param {Object} options - Configuration options
+   * @param {function(Event): void} options.onOpen - Callback for socket open events
+   * @param {function(Event): void} options.onClose - Callback for socket close events
+   * @param {function(Event): void} options.onError - Callback for socket error events
+   * @param {function(import('../types/protocol.ts').RosbridgeMessage): void} options.onMessage - Callback for processed messages
+   * @param {function(any, function): void} [options.decoder] - Optional decoder function
+   */
+  constructor(socket, options) {
+    this.socket = socket;
+    this.onOpenCallback = options.onOpen;
+    this.onCloseCallback = options.onClose;
+    this.onErrorCallback = options.onError;
+    this.onMessageCallback = options.onMessage;
+    this.decoder = options.decoder || null;
+
+    /**
+     * Buffer Map for incoming message fragments
+     * @type {Map<string, {fragments: Array<string>, received: number, total: number}>}
+     */
+    this.fragmentBuffer = new Map();
+
+    this.setupEventListeners();
   }
 
   /**
-   * Buffer Map for incoming message fragments
-   * @type {Map<string, {fragments: Array<string>, received: number, total: number}>}
+   * Set up event listeners on the socket
+   * @private
    */
-  const fragmentBuffer = new Map();
+  setupEventListeners() {
+    this.socket.onopen = (event) => this.onopen(event);
+    this.socket.onclose = (event) => this.onclose(event);
+    this.socket.onerror = (event) => this.onerror(event);
+    this.socket.onmessage = (data) => this.onmessage(data);
+  }
 
   /**
    * @param {import('../types/protocol.ts').RosbridgeMessage} message
    */
-  function handleMessage(message) {
+  handleMessage(message) {
     if (isRosbridgeFragmentMessage(message)) {
-      handleFragment(message);
-    } else if (isRosbridgePublishMessage(message)) {
-      client.emit(message.topic, message.msg);
-    } else if (isRosbridgeServiceResponseMessage(message)) {
-      if (message.id) {
-        client.emit(message.id, message);
-      } else {
-        console.error("Received service response without ID");
-      }
-    } else if (isRosbridgeCallServiceMessage(message)) {
-      client.emit(message.service, message);
-    } else if (isRosbridgeSendActionGoalMessage(message)) {
-      client.emit(message.action, message);
-    } else if (isRosbridgeCancelActionGoalMessage(message)) {
-      client.emit(message.id, message);
-    } else if (isRosbridgeActionFeedbackMessage(message)) {
-      client.emit(message.id, message);
-    } else if (isRosbridgeActionResultMessage(message)) {
-      client.emit(message.id, message);
-    } else if (isRosbridgeStatusMessage(message)) {
-      if (message.id) {
-        client.emit("status:" + message.id, message);
-      } else {
-        client.emit("status", message);
-      }
+      this.handleFragment(message);
+    } else {
+      // Delegate message processing to the callback
+      this.onMessageCallback(message);
     }
   }
 
   /**
    * @param {import('../types/protocol.ts').RosbridgeFragmentMessage} fragment
    */
-  function handleFragment(fragment) {
+  handleFragment(fragment) {
     const { id, data, num, total } = fragment;
     if (
       !id ||
@@ -98,10 +84,14 @@ export default function SocketAdapter(client) {
     }
     // If total is a float, use its integer part for fragment count
     const totalInt = Math.floor(total);
-    if (!fragmentBuffer.has(id)) {
-      fragmentBuffer.set(id, { fragments: [], received: 0, total: totalInt });
+    if (!this.fragmentBuffer.has(id)) {
+      this.fragmentBuffer.set(id, {
+        fragments: [],
+        received: 0,
+        total: totalInt,
+      });
     }
-    const entry = fragmentBuffer.get(id);
+    const entry = this.fragmentBuffer.get(id);
 
     if (!entry) {
       // Should not happen, signal error
@@ -122,11 +112,11 @@ export default function SocketAdapter(client) {
         message = JSON.parse(fullData);
       } catch {
         // Failed to parse, ignore
-        fragmentBuffer.delete(id);
+        this.fragmentBuffer.delete(id);
         return;
       }
-      fragmentBuffer.delete(id);
-      handleMessage(message);
+      this.fragmentBuffer.delete(id);
+      this.handleMessage(message);
     }
   }
 
@@ -134,7 +124,7 @@ export default function SocketAdapter(client) {
    * @param {import('../types/protocol.ts').RosbridgeMessage} message
    * @param {(message: import('../types/protocol.ts').RosbridgeMessage) => void} callback
    */
-  function handlePng(message, callback) {
+  handlePng(message, callback) {
     if (isRosbridgePngMessage(message)) {
       // If in Node.js..
       if (typeof window === "undefined") {
@@ -156,7 +146,7 @@ export default function SocketAdapter(client) {
     }
   }
 
-  function decodeBSON(data, callback) {
+  decodeBSON(data, callback) {
     if (!BSON) {
       throw "Cannot process BSON encoded message without BSON header.";
     }
@@ -170,62 +160,87 @@ export default function SocketAdapter(client) {
     reader.readAsArrayBuffer(data);
   }
 
-  return {
-    /**
-     * Emit a 'connection' event on WebSocket connection.
-     *
-     * @param {function} event - The argument to emit with the event.
-     * @memberof SocketAdapter
-     */
-    onopen: function onOpen(event) {
-      client.isConnected = true;
-      client.emit("connection", event);
-    },
+  /**
+   * Send data through the socket
+   * @param {string|ArrayBuffer|Blob} data - Data to send
+   */
+  send(data) {
+    // Check readyState for both WebSocket and RTCDataChannel
+    const isOpen =
+      this.socket.readyState === 1 || // WebSocket.OPEN
+      this.socket.readyState === "open"; // RTCDataChannel 'open'
+    if (isOpen) {
+      // @ts-expect-error -- WebSocket and RTCDataChannel have compatible send methods in practice
+      this.socket.send(data);
+    }
+  }
 
-    /**
-     * Emit a 'close' event on WebSocket disconnection.
-     *
-     * @param {function} event - The argument to emit with the event.
-     * @memberof SocketAdapter
-     */
-    onclose: function onClose(event) {
-      client.isConnected = false;
-      client.emit("close", event);
-    },
+  /**
+   * Close the socket connection
+   */
+  close() {
+    this.socket.close();
+  }
 
-    /**
-     * Emit an 'error' event whenever there was an error.
-     *
-     * @param {function} event - The argument to emit with the event.
-     * @memberof SocketAdapter
-     */
-    onerror: function onError(event) {
-      client.emit("error", event);
-    },
+  /**
+   * Get the current connection state
+   * @returns {number|string} The socket ready state
+   */
+  get readyState() {
+    return this.socket.readyState;
+  }
 
-    /**
-     * Parse message responses from rosbridge and send to the appropriate
-     * topic, service, or param.
-     *
-     * @param {Object} data - The raw JSON message from rosbridge.
-     * @memberof SocketAdapter
-     */
-    onmessage: function onMessage(data) {
-      if (decoder) {
-        decoder(data.data, function (message) {
-          handleMessage(message);
-        });
-      } else if (typeof Blob !== "undefined" && data.data instanceof Blob) {
-        decodeBSON(data.data, function (message) {
-          handlePng(message, handleMessage);
-        });
-      } else if (data.data instanceof ArrayBuffer) {
-        const decoded = CBOR.decode(data.data, typedArrayTagger);
-        handleMessage(decoded);
-      } else {
-        const message = JSON.parse(typeof data === "string" ? data : data.data);
-        handlePng(message, handleMessage);
-      }
-    },
-  };
+  /**
+   * Handle socket open event.
+   *
+   * @param {Event} event - The open event
+   * @memberof SocketAdapter
+   */
+  onopen(event) {
+    this.onOpenCallback(event);
+  }
+
+  /**
+   * Handle socket close event.
+   *
+   * @param {Event} event - The close event
+   * @memberof SocketAdapter
+   */
+  onclose(event) {
+    this.onCloseCallback(event);
+  }
+
+  /**
+   * Handle socket error event.
+   *
+   * @param {Event} event - The error event
+   * @memberof SocketAdapter
+   */
+  onerror(event) {
+    this.onErrorCallback(event);
+  }
+
+  /**
+   * Handle incoming socket message and decode it appropriately.
+   *
+   * @param {Object} data - The raw message data from the socket.
+   * @memberof SocketAdapter
+   */
+  onmessage(data) {
+    if (this.decoder) {
+      this.decoder(data.data, (message) => {
+        this.handleMessage(message);
+      });
+    } else if (typeof Blob !== "undefined" && data.data instanceof Blob) {
+      this.decodeBSON(data.data, (message) => {
+        this.handlePng(message, this.handleMessage.bind(this));
+      });
+    } else if (data.data instanceof ArrayBuffer) {
+      const decoded = CBOR.decode(data.data, typedArrayTagger);
+      this.handleMessage(decoded);
+    } else {
+      const message = JSON.parse(typeof data === "string" ? data : data.data);
+      this.handlePng(message, this.handleMessage.bind(this));
+    }
+  }
 }

--- a/test/SocketAdapter.test.ts
+++ b/test/SocketAdapter.test.ts
@@ -4,19 +4,53 @@ import SocketAdapter from "../src/core/SocketAdapter.js";
 describe("SocketAdapter fragment handling", () => {
   let client;
   let adapter;
+  let mockSocket;
 
   beforeEach(() => {
     client = {
       emit: vi.fn(),
       transportOptions: {},
     };
-    adapter = SocketAdapter(client);
+
+    // Create mock WebSocket
+    mockSocket = {
+      onopen: null,
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+      readyState: 1, // WebSocket.OPEN
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const options = {
+      onOpen: (event) => {
+        client.isConnected = true;
+        client.emit("connection", event);
+      },
+      onClose: (event) => {
+        client.isConnected = false;
+        client.emit("close", event);
+      },
+      onError: (event) => {
+        client.emit("error", event);
+      },
+      onMessage: (message) => {
+        // Simulate Ros.js message handling
+        if (message.op === "publish") {
+          client.emit(message.topic, message.msg);
+        }
+      },
+    };
+
+    adapter = new SocketAdapter(mockSocket, options);
     vi.clearAllMocks();
   });
 
   function sendFragment(id, total, fragments) {
     for (let i = 0; i < fragments.length; i++) {
-      adapter.onmessage({
+      // Simulate socket receiving a message
+      mockSocket.onmessage({
         data: JSON.stringify({
           op: "fragment",
           id,
@@ -50,7 +84,7 @@ describe("SocketAdapter fragment handling", () => {
     expect(client.emit).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores extra fragments beyond integer total", () => {
+  it("handles extra fragments beyond integer total", () => {
     const id = "test3";
     const total = 2.1;
     const msg = { op: "publish", topic: "baz", msg: { data: 7 } };
@@ -72,7 +106,55 @@ describe("SocketAdapter fragment handling", () => {
   });
 
   it("ignores malformed fragments", () => {
-    adapter.onmessage({ data: JSON.stringify({ op: "fragment", id: "bad" }) });
+    mockSocket.onmessage({
+      data: JSON.stringify({ op: "fragment", id: "bad" }),
+    });
     expect(client.emit).not.toHaveBeenCalled();
+  });
+
+  describe("socket event handling", () => {
+    it("handles socket open event", () => {
+      mockSocket.onopen({ type: "open" });
+      expect(client.isConnected).toBe(true);
+      expect(client.emit).toHaveBeenCalledWith("connection", { type: "open" });
+    });
+
+    it("handles socket close event", () => {
+      client.isConnected = true;
+      mockSocket.onclose({ type: "close" });
+      expect(client.isConnected).toBe(false);
+      expect(client.emit).toHaveBeenCalledWith("close", { type: "close" });
+    });
+
+    it("handles socket error event", () => {
+      const errorEvent = { type: "error", message: "Connection failed" };
+      mockSocket.onerror(errorEvent);
+      expect(client.emit).toHaveBeenCalledWith("error", errorEvent);
+    });
+  });
+
+  describe("socket proxy methods", () => {
+    it("sends data when socket is open", () => {
+      const testData = "test message";
+      adapter.send(testData);
+      expect(mockSocket.send).toHaveBeenCalledWith(testData);
+    });
+
+    it("does not send data when socket is closed", () => {
+      mockSocket.readyState = 3; // WebSocket.CLOSED
+      const testData = "test message";
+      adapter.send(testData);
+      expect(mockSocket.send).not.toHaveBeenCalled();
+    });
+
+    it("closes the socket", () => {
+      adapter.close();
+      expect(mockSocket.close).toHaveBeenCalled();
+    });
+
+    it("returns socket readyState", () => {
+      mockSocket.readyState = 2; // WebSocket.CLOSING
+      expect(adapter.readyState).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
I think this is a more sensical approach to this problem. SocketAdapter provides a coherent ROS API on top of either a browser WebSocket, a ws WebSocket, or an RTCDataChannel - it should be written as a wrapper.

This technically breaks an API, but only because of Hyrum's Law.. I hope nobody was interacting directly with the `.socket` member of `Ros` 🤦🏻 

## This contains no functional changes, it just changes the scope of some of the socket-handling callbacks to be less confusing.