### PR TITLE
Make all failureCallbacks default to console.error

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -36,6 +36,7 @@ export default tseslint.config(
       "@typescript-eslint/no-namespace": 0,
       // Plenty of APIs (like mocking APIs in Vitest) require empty functions to be declared.
       "@typescript-eslint/no-empty-function": 0,
+      "@typescript-eslint/no-unnecessary-condition": "error",
     },
   },
   {

--- a/src/actionlib/ActionClient.ts
+++ b/src/actionlib/ActionClient.ts
@@ -26,7 +26,7 @@ export default class ActionClient<
 > extends EventEmitter<{
   timeout: void;
 }> {
-  goals: Record<string, Goal<TGoal>> = {};
+  goals: Partial<Record<string, Goal<TGoal>>> = {};
   /** flag to check if a status has been received */
   receivedStatus = false;
   ros: Ros;

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -59,7 +59,7 @@ export default class Action<
     goal: TGoal,
     resultCallback: (result: TResult) => void,
     feedbackCallback?: (feedback: TFeedback) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     if (this.isAdvertised) {
       return;
@@ -68,19 +68,17 @@ export default class Action<
     const actionGoalId =
       "send_action_goal:" + this.name + ":" + ++this.ros.idCounter;
 
-    if (resultCallback || failedCallback) {
-      this.ros.on(actionGoalId, function (message) {
-        if (isRosbridgeActionResultMessage<TResult>(message)) {
-          if (!message.result) {
-            failedCallback?.(message.values ?? "");
-          } else {
-            resultCallback?.(message.values);
-          }
-        } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
-          feedbackCallback?.(message.values);
+    this.ros.on(actionGoalId, function (message) {
+      if (isRosbridgeActionResultMessage<TResult>(message)) {
+        if (!message.result) {
+          failedCallback(message.values ?? "");
+        } else {
+          resultCallback(message.values);
         }
-      });
-    }
+      } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
+        feedbackCallback?.(message.values);
+      }
+    });
 
     const call = {
       op: "send_action_goal",
@@ -166,7 +164,7 @@ export default class Action<
       this.ros.on(id, (message) => {
         if (
           isRosbridgeCancelActionGoalMessage(message) &&
-          typeof this.#cancelCallback === "function"
+          this.#cancelCallback
         ) {
           this.#cancelCallback(id);
         }
@@ -174,7 +172,7 @@ export default class Action<
     }
 
     // Call the action goal execution function provided.
-    if (typeof this.#actionCallback === "function") {
+    if (this.#actionCallback) {
       this.#actionCallback(rosbridgeRequest.args, id);
     }
   }

--- a/src/core/Param.ts
+++ b/src/core/Param.ts
@@ -28,7 +28,10 @@ export default class Param<T = unknown> {
    * @param callback - The callback function.
    * @param [failedCallback] - The callback function when the service call failed or the parameter retrieval was unsuccessful.
    */
-  get(callback: (value: T) => void, failedCallback?: (error: string) => void) {
+  get(
+    callback: (value: T) => void,
+    failedCallback: (error: string) => void = console.error,
+  ) {
     const paramClient = new Service<
       rosapi.GetParamRequest,
       rosapi.GetParamResponse
@@ -43,7 +46,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful === false && failedCallback) {
+        if (result.successful === false) {
           failedCallback(result.reason);
         } else {
           const value = JSON.parse(result.value);
@@ -63,7 +66,7 @@ export default class Param<T = unknown> {
   set(
     value: object,
     callback?: (message: rosapi.SetParamResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const paramClient = new Service<
       rosapi.SetParamRequest,
@@ -82,7 +85,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful === false && failedCallback) {
+        if (result.successful === false) {
           failedCallback(result.reason);
         } else if (callback) {
           callback(result);
@@ -99,7 +102,7 @@ export default class Param<T = unknown> {
    */
   delete(
     callback: (message: rosapi.DeleteParamResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const paramClient = new Service<
       rosapi.DeleteParamRequest,
@@ -117,9 +120,9 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful === false && failedCallback) {
+        if (result.successful === false) {
           failedCallback(result.reason);
-        } else if (callback) {
+        } else {
           callback(result);
         }
       },

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -274,7 +274,7 @@ export default class Ros extends EventEmitter<
    */
   getActionServers(
     callback: (actionservers: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const getActionServers = new Service<
       rosapi.GetActionServersRequest,
@@ -286,21 +286,15 @@ export default class Ros extends EventEmitter<
     });
 
     const request = {};
-    if (typeof failedCallback === "function") {
-      getActionServers.callService(
-        request,
-        function (result) {
-          callback(result.action_servers);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      getActionServers.callService(request, function (result) {
+    getActionServers.callService(
+      request,
+      function (result) {
         callback(result.action_servers);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve a list of topics in ROS as an array.
@@ -310,7 +304,7 @@ export default class Ros extends EventEmitter<
    */
   getTopics(
     callback: (result: rosapi.TopicsResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const topicsClient = new Service<
       rosapi.TopicsRequest,
@@ -322,21 +316,15 @@ export default class Ros extends EventEmitter<
     });
 
     const request = {};
-    if (typeof failedCallback === "function") {
-      topicsClient.callService(
-        request,
-        function (result) {
-          callback(result);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      topicsClient.callService(request, function (result) {
+    topicsClient.callService(
+      request,
+      function (result) {
         callback(result);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve a list of topics in ROS as an array of a specific type.
@@ -348,7 +336,7 @@ export default class Ros extends EventEmitter<
   getTopicsForType(
     topicType: string,
     callback: (topics: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const topicsForTypeClient = new Service<
       rosapi.TopicsForTypeRequest,
@@ -362,21 +350,15 @@ export default class Ros extends EventEmitter<
     const request = {
       type: topicType,
     };
-    if (typeof failedCallback === "function") {
-      topicsForTypeClient.callService(
-        request,
-        function (result) {
-          callback(result.topics);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      topicsForTypeClient.callService(request, function (result) {
+    topicsForTypeClient.callService(
+      request,
+      function (result) {
         callback(result.topics);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
 
   /**
@@ -387,7 +369,7 @@ export default class Ros extends EventEmitter<
    */
   getServices(
     callback: (services: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const servicesClient = new Service<
       rosapi.ServicesRequest,
@@ -399,21 +381,15 @@ export default class Ros extends EventEmitter<
     });
 
     const request = {};
-    if (typeof failedCallback === "function") {
-      servicesClient.callService(
-        request,
-        function (result) {
-          callback(result.services);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      servicesClient.callService(request, function (result) {
+    servicesClient.callService(
+      request,
+      function (result) {
         callback(result.services);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve a list of services in ROS as an array as specific type.
@@ -425,7 +401,7 @@ export default class Ros extends EventEmitter<
   getServicesForType(
     serviceType: string,
     callback: (services: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const servicesForTypeClient = new Service<
       rosapi.ServicesForTypeRequest,
@@ -439,21 +415,15 @@ export default class Ros extends EventEmitter<
     const request = {
       type: serviceType,
     };
-    if (typeof failedCallback === "function") {
-      servicesForTypeClient.callService(
-        request,
-        function (result) {
-          callback(result.services);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      servicesForTypeClient.callService(request, function (result) {
+    servicesForTypeClient.callService(
+      request,
+      function (result) {
         callback(result.services);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve the details of a ROS service request.
@@ -465,7 +435,7 @@ export default class Ros extends EventEmitter<
   getServiceRequestDetails(
     type: string,
     callback: (result: rosapi.ServiceRequestDetailsResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const serviceTypeClient = new Service<
       rosapi.ServiceRequestDetailsRequest,
@@ -479,21 +449,15 @@ export default class Ros extends EventEmitter<
       type: type,
     };
 
-    if (typeof failedCallback === "function") {
-      serviceTypeClient.callService(
-        request,
-        function (result) {
-          callback(result);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      serviceTypeClient.callService(request, function (result) {
+    serviceTypeClient.callService(
+      request,
+      function (result) {
         callback(result);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve the details of a ROS service response.
@@ -505,7 +469,7 @@ export default class Ros extends EventEmitter<
   getServiceResponseDetails(
     type: string,
     callback: (result: rosapi.ServiceResponseDetailsResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const serviceTypeClient = new Service<
       rosapi.ServiceResponseDetailsRequest,
@@ -519,21 +483,15 @@ export default class Ros extends EventEmitter<
       type: type,
     };
 
-    if (typeof failedCallback === "function") {
-      serviceTypeClient.callService(
-        request,
-        function (result) {
-          callback(result);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      serviceTypeClient.callService(request, function (result) {
+    serviceTypeClient.callService(
+      request,
+      function (result) {
         callback(result);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve a list of active node names in ROS.
@@ -543,7 +501,7 @@ export default class Ros extends EventEmitter<
    */
   getNodes(
     callback: (result: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const nodesClient = new Service<rosapi.NodesRequest, rosapi.NodesResponse>({
       ros: this,
@@ -552,21 +510,15 @@ export default class Ros extends EventEmitter<
     });
 
     const request = {};
-    if (typeof failedCallback === "function") {
-      nodesClient.callService(
-        request,
-        function (result) {
-          callback(result.nodes);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      nodesClient.callService(request, function (result) {
+    nodesClient.callService(
+      request,
+      function (result) {
         callback(result.nodes);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve a list of subscribed topics, publishing topics and services of a specific node.
@@ -576,7 +528,7 @@ export default class Ros extends EventEmitter<
   getNodeDetails(
     node: string,
     callback: (result: rosapi.NodeDetailsResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const nodesClient = new Service<
       rosapi.NodeDetailsRequest,
@@ -597,7 +549,7 @@ export default class Ros extends EventEmitter<
    */
   getParams(
     callback: (names: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const paramsClient = new Service<
       rosapi.GetParamNamesRequest,
@@ -608,21 +560,15 @@ export default class Ros extends EventEmitter<
       serviceType: "rosapi/GetParamNames",
     });
     const request = {};
-    if (typeof failedCallback === "function") {
-      paramsClient.callService(
-        request,
-        function (result) {
-          callback(result.names);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      paramsClient.callService(request, function (result) {
+    paramsClient.callService(
+      request,
+      function (result) {
         callback(result.names);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve the type of a ROS topic.
@@ -634,7 +580,7 @@ export default class Ros extends EventEmitter<
   getTopicType(
     topic: string,
     callback: (type: string) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const topicTypeClient = new Service<
       rosapi.TopicTypeRequest,
@@ -648,21 +594,15 @@ export default class Ros extends EventEmitter<
       topic: topic,
     };
 
-    if (typeof failedCallback === "function") {
-      topicTypeClient.callService(
-        request,
-        function (result) {
-          callback(result.type);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      topicTypeClient.callService(request, function (result) {
+    topicTypeClient.callService(
+      request,
+      function (result) {
         callback(result.type);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve the type of a ROS service.
@@ -674,7 +614,7 @@ export default class Ros extends EventEmitter<
   getServiceType(
     service: string,
     callback: (type: string) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const serviceTypeClient = new Service<
       rosapi.ServiceTypeRequest,
@@ -688,21 +628,15 @@ export default class Ros extends EventEmitter<
       service: service,
     };
 
-    if (typeof failedCallback === "function") {
-      serviceTypeClient.callService(
-        request,
-        function (result) {
-          callback(result.type);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      serviceTypeClient.callService(request, function (result) {
+    serviceTypeClient.callService(
+      request,
+      function (result) {
         callback(result.type);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Retrieve the details of a ROS message.
@@ -714,7 +648,7 @@ export default class Ros extends EventEmitter<
   getMessageDetails(
     message: string,
     callback: (typedefs: rosapi.TypeDef[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const messageDetailClient = new Service<
       rosapi.MessageDetailsRequest,
@@ -728,21 +662,15 @@ export default class Ros extends EventEmitter<
       type: message,
     };
 
-    if (typeof failedCallback === "function") {
-      messageDetailClient.callService(
-        request,
-        function (result) {
-          callback(result.typedefs);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      messageDetailClient.callService(request, function (result) {
+    messageDetailClient.callService(
+      request,
+      function (result) {
         callback(result.typedefs);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   /**
    * Decode a typedef array into a dictionary like `rosmsg show foo/bar`.
@@ -812,7 +740,7 @@ export default class Ros extends EventEmitter<
    */
   getTopicsAndRawTypes(
     callback: (result: rosapi.TopicsAndRawTypesResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const topicsAndRawTypesClient = new Service<
       rosapi.TopicsAndRawTypesRequest,
@@ -824,21 +752,15 @@ export default class Ros extends EventEmitter<
     });
 
     const request = {};
-    if (typeof failedCallback === "function") {
-      topicsAndRawTypesClient.callService(
-        request,
-        function (result) {
-          callback(result);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      topicsAndRawTypesClient.callService(request, function (result) {
+    topicsAndRawTypesClient.callService(
+      request,
+      function (result) {
         callback(result);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
   Topic(options) {
     return new Topic({ ros: this, ...options });

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -68,7 +68,7 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
   callService(
     request: TRequest,
     callback?: (response: TResponse) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
     timeout?: number,
   ): void {
     if (this.isAdvertised) {
@@ -78,17 +78,15 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
     const serviceCallId =
       "call_service:" + this.name + ":" + (++this.ros.idCounter).toString();
 
-    if (callback || failedCallback) {
-      this.ros.once(serviceCallId, function (message) {
-        if (isRosbridgeServiceResponseMessage<TResponse>(message)) {
-          if (!message.result) {
-            failedCallback?.(message.values ?? "");
-          } else {
-            callback?.(message.values);
-          }
+    this.ros.once(serviceCallId, function (message) {
+      if (isRosbridgeServiceResponseMessage<TResponse>(message)) {
+        if (!message.result) {
+          failedCallback(message.values ?? "");
+        } else {
+          callback?.(message.values);
         }
-      });
-    }
+      }
+    });
 
     const call = {
       op: "call_service",

--- a/src/core/Topic.ts
+++ b/src/core/Topic.ts
@@ -141,9 +141,7 @@ export default class Topic<T> extends EventEmitter<{
    * @param callback - Function with the following params:
    */
   subscribe(callback: (message: T) => void) {
-    if (typeof callback === "function") {
-      this.on("message", callback);
-    }
+    this.on("message", callback);
 
     if (this.subscribeId) {
       return;
@@ -268,7 +266,7 @@ export default class Topic<T> extends EventEmitter<{
    */
   getPublishers(
     callback: (publishers: string[]) => void,
-    failedCallback?: (error: string) => void,
+    failedCallback: (error: string) => void = console.error,
   ) {
     const publishersClient = new Service<
       rosapi.PublishersRequest,
@@ -282,20 +280,14 @@ export default class Topic<T> extends EventEmitter<{
     const request = {
       topic: this.name,
     };
-    if (typeof failedCallback === "function") {
-      publishersClient.callService(
-        request,
-        function (result) {
-          callback(result.publishers);
-        },
-        function (message) {
-          failedCallback(message);
-        },
-      );
-    } else {
-      publishersClient.callService(request, function (result) {
+    publishersClient.callService(
+      request,
+      function (result) {
         callback(result.publishers);
-      });
-    }
+      },
+      function (message) {
+        failedCallback(message);
+      },
+    );
   }
 }

--- a/src/tf/BaseTFClient.ts
+++ b/src/tf/BaseTFClient.ts
@@ -7,9 +7,8 @@ import { std_msgs } from "../types/std_msgs.js";
  * Base class for TF Clients that provides common functionality.
  */
 export default class BaseTFClient {
-  frameInfos: Record<
-    string,
-    { transform?: Transform; cbs: ((tf: Transform) => void)[] }
+  frameInfos: Partial<
+    Record<string, { transform?: Transform; cbs: ((tf: Transform) => void)[] }>
   > = {};
   republisherUpdateRequested = false;
   ros: Ros;
@@ -124,20 +123,20 @@ export default class BaseTFClient {
     }
 
     // if we already have a transform, callback immediately
-    const transform = this.frameInfos[frameID].transform;
+    const transform = this.frameInfos[frameID]?.transform;
     if (transform) {
       callback(transform);
     }
-    this.frameInfos[frameID].cbs.push(callback);
+    this.frameInfos[frameID]?.cbs.push(callback);
   }
 
   /**
    * Unsubscribe from the given TF frame.
    *
    * @param frameID - The TF frame to unsubscribe from.
-   * @param callback - The callback function to remove.
+   * @param [callback] - The callback function to remove.
    */
-  unsubscribe(frameID: string, callback: (transform: Transform) => void) {
+  unsubscribe(frameID: string, callback?: (transform: Transform) => void) {
     // remove leading slash, if it's there
     if (frameID.startsWith("/")) {
       frameID = frameID.substring(1);


### PR DESCRIPTION


**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

None, but you'll get logs when things fail now!

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Inspired by the PR in which I'm wrestling with unit tests..

Also cleaned up a few weirdo callback logic cases with the help of a typescript-eslint rule banning unnecessary conditions.

<!-- Link relevant GitHub issues -->
