### PR TITLE
Remove `groovyCompatibility` flag

### DIFF
--- a/examples/tf.html
+++ b/examples/tf.html
@@ -8,12 +8,7 @@
 <script>
   // Connecting to ROS
   // -----------------
-  var ros = new ROSLIB.Ros({
-    // set this to false to use the new service interface to
-    // tf2_web_republisher. true is the default and means roslibjs
-    // will use the action interface
-    groovyCompatibility : true
-  });
+  var ros = new ROSLIB.Ros();
 
   // If there is an error on the backend, an 'error' emit will be emitted.
   ros.on('error', function(error) {

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -49,11 +49,9 @@ export default class Ros extends EventEmitter<
   isConnected = false;
   transportLibrary: "websocket" | RTCPeerConnection;
   transportOptions;
-  groovyCompatibility: boolean;
   /**
    * @param [options]
    * @param [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.
-   * @param [options.groovyCompatibility=true] - Don't use interfaces that changed after the last groovy release or rosbridge_suite and related tools.
    * @param [options.transportLibrary='websocket'] - 'websocket', or an RTCPeerConnection instance controlling how the connection is created in `connect`.
    * @param [options.transportOptions={}] - The options to use when creating a connection. Currently only used if `transportLibrary` is RTCPeerConnection.
    */
@@ -61,10 +59,8 @@ export default class Ros extends EventEmitter<
     url,
     transportLibrary = "websocket",
     transportOptions = {},
-    groovyCompatibility = true,
   }: {
     url?: string;
-    groovyCompatibility?: boolean;
     transportLibrary?: "websocket" | RTCPeerConnection;
     transportOptions?: object;
   } = {}) {
@@ -72,7 +68,6 @@ export default class Ros extends EventEmitter<
 
     this.transportLibrary = transportLibrary;
     this.transportOptions = transportOptions;
-    this.groovyCompatibility = groovyCompatibility;
 
     // begin by checking if a URL was given
     if (url) {

--- a/src/tf/TFClient.ts
+++ b/src/tf/TFClient.ts
@@ -6,9 +6,7 @@
 import ActionClient from "../actionlib/ActionClient.js";
 import Goal from "../actionlib/Goal.js";
 
-import Service from "../core/Service.js";
 import Topic from "../core/Topic.js";
-import Ros from "../core/Ros.js";
 import { tf2_msgs } from "../types/tf2_msgs.js";
 import { tf2_web_republisher } from "../types/tf2_web_republisher.js";
 
@@ -20,12 +18,7 @@ import BaseTFClient from "./BaseTFClient.js";
 export default class TFClient extends BaseTFClient {
   currentGoal: Goal<tf2_web_republisher.TFSubscriptionGoal> | false = false;
   currentTopic: Topic<tf2_msgs.TFMessage> | false = false;
-  repubServiceName: string;
   actionClient: ActionClient<tf2_web_republisher.TFSubscriptionGoal>;
-  serviceClient: Service<
-    tf2_web_republisher.RepublishTFsRequest,
-    tf2_web_republisher.RepublishTFsResponse
-  >;
   #subscribeCB: ((tf: tf2_msgs.TFMessage) => void) | undefined = undefined;
   #isDisposed = false;
 
@@ -40,25 +33,9 @@ export default class TFClient extends BaseTFClient {
    *     to update the TF republisher's list of TFs.
    * @param [options.topicTimeout=2.0] - The timeout parameter for the TF republisher.
    * @param [options.serverName="/tf2_web_republisher"] - The name of the tf2_web_republisher server.
-   * @param [options.repubServiceName="/republish_tfs"] - The name of the republish_tfs service (non groovy compatibility mode only).
    */
-  constructor({
-    repubServiceName = "/republish_tfs",
-    ...options
-  }: {
-    ros: Ros;
-    fixedFrame?: string;
-    angularThres?: number;
-    transThres?: number;
-    rate?: number;
-    updateDelay?: number;
-    topicTimeout?: number;
-    serverName?: string;
-    repubServiceName?: string;
-  }) {
+  constructor(options: ConstructorParameters<typeof BaseTFClient>[0]) {
     super(options);
-
-    this.repubServiceName = repubServiceName;
 
     // Create an Action Client
     this.actionClient = new ActionClient({
@@ -67,13 +44,6 @@ export default class TFClient extends BaseTFClient {
       actionName: "tf2_web_republisher/TFSubscriptionAction",
       omitStatus: true,
       omitResult: true,
-    });
-
-    // Create a Service Client
-    this.serviceClient = new Service({
-      ros: this.ros,
-      name: this.repubServiceName,
-      serviceType: "tf2_web_republisher/RepublishTFs",
     });
   }
 
@@ -90,32 +60,16 @@ export default class TFClient extends BaseTFClient {
       rate: this.rate,
     };
 
-    /*
-     * if we're running in groovy compatibility mode (the default)
-     * then use the action interface to tf2_web_republisher
-     */
-    if (this.ros.groovyCompatibility) {
-      if (this.currentGoal) {
-        this.currentGoal.cancel();
-      }
-      this.currentGoal = new Goal<tf2_web_republisher.TFSubscriptionGoal>({
-        actionClient: this.actionClient,
-        goalMessage: goalMessage,
-      });
-
-      this.currentGoal.on("feedback", this.processTFArray.bind(this));
-      this.currentGoal.send();
-    } else {
-      /*
-       * otherwise, use the service interface
-       * The service interface has the same parameters as the action,
-       * plus the timeout
-       */
-      this.serviceClient.callService(
-        { ...goalMessage, timeout: this.topicTimeout },
-        this.processResponse.bind(this),
-      );
+    if (this.currentGoal) {
+      this.currentGoal.cancel();
     }
+    this.currentGoal = new Goal<tf2_web_republisher.TFSubscriptionGoal>({
+      actionClient: this.actionClient,
+      goalMessage: goalMessage,
+    });
+
+    this.currentGoal.on("feedback", this.processTFArray.bind(this));
+    this.currentGoal.send();
 
     this.republisherUpdateRequested = false;
   }

--- a/test/examples/tf_service.example.ts
+++ b/test/examples/tf_service.example.ts
@@ -9,29 +9,6 @@ describe.skipIf(process.env.ROS_DISTRO !== "noetic")(
     it("tf republisher", () =>
       new Promise<void>((done) => {
         const ros = new ROSLIB.Ros({
-          // Use the service interface to tf2_web_republisher
-          groovyCompatibility: false,
-        });
-        ros.connect("ws://localhost:9090");
-
-        const tfClient = new ROSLIB.TFClient({
-          ros: ros,
-          fixedFrame: "world",
-          angularThres: 0.01,
-          transThres: 0.01,
-        });
-
-        // Subscribe to a turtle.
-        tfClient.subscribe("turtle1", function (tf) {
-          expect(tf.rotation).to.be.eql(new ROSLIB.Quaternion());
-          expect(tf.translation).to.be.a.instanceof(ROSLIB.Vector3);
-          done();
-        });
-      }));
-
-    it("tf republisher alternative syntax", () =>
-      new Promise<void>((done) => {
-        const ros = new ROSLIB.Ros({
           url: "ws://localhost:9090",
         });
 


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

None, since the interface never got removed. Because TypeScript does not (by default) reject extra parameters in an options object passed to a function, this shouldn't even require code changes from client code.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

The interface this flags never actually got removed from the ROS 1 version of `tf2_web_republisher`, so the flag is unnecessary.

<!-- Link relevant GitHub issues -->
