### PR TITLE
Upgrade strictness of typescript eslint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -13,7 +13,7 @@ export default tseslint.config(
     files: ["**/*.{js,jsx,ts,tsx,cjs}"],
     extends: [
       ...tseslint.configs.recommendedTypeChecked,
-      ...tseslint.configs.stylistic,
+      ...tseslint.configs.stylisticTypeChecked,
     ],
     languageOptions: {
       parser: tseslint.parser,

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,10 @@ export default tseslint.config(
   {
     // Linting rules for TS files, should be combined with the base config when migration is complete
     files: ["**/*.{js,jsx,ts,tsx,cjs}"],
-    extends: [...tseslint.configs.recommended, ...tseslint.configs.stylistic],
+    extends: [
+      ...tseslint.configs.recommendedTypeChecked,
+      ...tseslint.configs.stylistic,
+    ],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,18 +1,17 @@
-// @ts-check
-
+import { defineConfig } from "eslint/config";
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import globals from "globals";
 import jsdoc from "eslint-plugin-jsdoc";
 import prettier from "eslint-plugin-prettier";
 
-export default tseslint.config(
+export default defineConfig(
   eslint.configs.recommended,
   {
     // Linting rules for TS files, should be combined with the base config when migration is complete
     files: ["**/*.{js,jsx,ts,tsx,cjs}"],
     extends: [
-      ...tseslint.configs.recommendedTypeChecked,
+      ...tseslint.configs.strictTypeChecked,
       ...tseslint.configs.stylisticTypeChecked,
     ],
     languageOptions: {
@@ -25,21 +24,11 @@ export default tseslint.config(
       prettier,
     },
     rules: {
-      eqeqeq: 2,
-      "wrap-iife": [2, "any"],
-      "no-use-before-define": 0,
-      "no-caller": 2,
-      "no-undef": 2,
-      "no-cond-assign": 0,
-      "no-eq-null": 0,
-      strict: 0,
       "prettier/prettier": [2, { endOfLine: "auto" }],
-      "no-proto": 2,
       // Disabled to allow namespaced ROS message types since that's how we think about message types in ROS
       "@typescript-eslint/no-namespace": 0,
       // Plenty of APIs (like mocking APIs in Vitest) require empty functions to be declared.
       "@typescript-eslint/no-empty-function": 0,
-      "@typescript-eslint/no-unnecessary-condition": "error",
     },
   },
   {

--- a/examples/node_simple.js
+++ b/examples/node_simple.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Connecting to ROS
-import ROSLIB from "roslib";
+import ROSLIB from "../src/index";
 
 const ros = new ROSLIB.Ros({
   url: "ws://localhost:9090",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@testing-library/react": "^16.0.0",
+        "@types/dockerode": "^3.3.45",
         "@types/node": "^24.0.1",
         "@types/ws": "^8.5.10",
         "dockerode": "^4.0.9",
@@ -1856,6 +1857,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "3.3.45",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.45.tgz",
+      "integrity": "sha512-iYpZF+xr5QLpIICejLdUF2r5gh8IXY1Gw3WLmt41dUbS3Vn/3hVgL+6lJBVbmrhYBWfbWPPstdr6+A0s95DTWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1901,6 +1925,33 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@testing-library/react": "^16.0.0",
+    "@types/dockerode": "^3.3.45",
     "@types/node": "^24.0.1",
     "@types/ws": "^8.5.10",
     "dockerode": "^4.0.9",

--- a/src/actionlib/ActionClient.ts
+++ b/src/actionlib/ActionClient.ts
@@ -24,7 +24,7 @@ export default class ActionClient<
   TFeedback = unknown,
   TResult = unknown,
 > extends EventEmitter<{
-  timeout: void;
+  timeout: undefined;
 }> {
   goals: Partial<Record<string, Goal<TGoal>>> = {};
   /** flag to check if a status has been received */

--- a/src/actionlib/Goal.ts
+++ b/src/actionlib/Goal.ts
@@ -18,7 +18,7 @@ export default class Goal<
   TFeedback = unknown,
   TResult = unknown,
 > extends EventEmitter<{
-  timeout: void;
+  timeout: undefined;
   status: [actionlib_msgs.GoalStatus];
   feedback: [TFeedback];
   result: [TResult];
@@ -28,7 +28,7 @@ export default class Goal<
   result?: TResult = undefined;
   feedback?: TFeedback = undefined;
   // Create a random ID
-  goalID = "goal_" + Math.random() + "_" + new Date().getTime();
+  goalID = `goal_${Math.random().toString()}_${new Date().getTime().toString()}`;
   actionClient: ActionClient<TGoal, TFeedback, TResult>;
   goalMessage: { goal: TGoal; goal_id: actionlib_msgs.GoalID };
   /**

--- a/src/actionlib/Goal.ts
+++ b/src/actionlib/Goal.ts
@@ -19,12 +19,12 @@ export default class Goal<
   TResult = unknown,
 > extends EventEmitter<{
   timeout: void;
-  status: actionlib_msgs.GoalStatus;
+  status: [actionlib_msgs.GoalStatus];
   feedback: [TFeedback];
   result: [TResult];
 }> {
   isFinished = false;
-  status = undefined;
+  status?: actionlib_msgs.GoalStatus = undefined;
   result?: TResult = undefined;
   feedback?: TFeedback = undefined;
   // Create a random ID

--- a/src/actionlib/SimpleActionServer.ts
+++ b/src/actionlib/SimpleActionServer.ts
@@ -7,6 +7,7 @@ import Ros from "../core/Ros.js";
 import Topic from "../core/Topic.js";
 import { EventEmitter } from "eventemitter3";
 import { actionlib_msgs } from "../types/actionlib_msgs.js";
+import { std_msgs } from "../types/std_msgs.js";
 
 /**
  * An actionlib action server client.
@@ -125,7 +126,7 @@ export default class SimpleActionServer<
      * helper function to determine ordering of timestamps
      * returns t1 < t2
      */
-    const isEarlier = function (t1, t2) {
+    const isEarlier = function (t1: std_msgs.time, t2: std_msgs.time) {
       if (t1.secs > t2.secs) {
         return false;
       } else if (t1.secs < t2.secs) {

--- a/src/actionlib/SimpleActionServer.ts
+++ b/src/actionlib/SimpleActionServer.ts
@@ -22,7 +22,7 @@ export default class SimpleActionServer<
   TResult = unknown,
 > extends EventEmitter<{
   goal: [TGoal];
-  cancel: void;
+  cancel: undefined;
 }> {
   // needed for handling preemption prompted by a new goal being received
   currentGoal: { goal: TGoal; goal_id: actionlib_msgs.GoalID } | null = null; // currently tracked goal

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -67,8 +67,7 @@ export default class Action<
       return;
     }
 
-    const actionGoalId =
-      "send_action_goal:" + this.name + ":" + ++this.ros.idCounter;
+    const actionGoalId = `send_action_goal:${this.name}:${(++this.ros.idCounter).toString()}`;
 
     this.ros.on(actionGoalId, function (message) {
       if (isRosbridgeActionResultMessage<TResult>(message)) {

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -8,6 +8,8 @@ import {
   isRosbridgeActionFeedbackMessage,
   isRosbridgeActionResultMessage,
   isRosbridgeCancelActionGoalMessage,
+  isRosbridgeSendActionGoalMessage,
+  RosbridgeSendActionGoalMessage,
 } from "../types/protocol.ts";
 import Ros from "./Ros.js";
 
@@ -124,7 +126,15 @@ export default class Action<
 
     this.#actionCallback = actionCallback;
     this.#cancelCallback = cancelCallback;
-    this.ros.on(this.name, this.#executeAction.bind(this));
+    this.ros.on(this.name, (msg) => {
+      if (isRosbridgeSendActionGoalMessage(msg)) {
+        this.#executeAction.bind(this);
+      } else {
+        throw new Error(
+          "Received unrelated message on Action server event stream!",
+        );
+      }
+    });
     this.ros.callOnConnection({
       op: "advertise_action",
       type: this.actionType,
@@ -156,7 +166,7 @@ export default class Action<
    * @param rosbridgeRequest.id - The ID of the action goal.
    * @param rosbridgeRequest.args - The arguments of the action goal.
    */
-  #executeAction(rosbridgeRequest: { id: string; args: TGoal }) {
+  #executeAction(rosbridgeRequest: RosbridgeSendActionGoalMessage<TGoal>) {
     const id = rosbridgeRequest.id;
 
     // If a cancellation callback exists, call it when a cancellation event is emitted.
@@ -173,7 +183,13 @@ export default class Action<
 
     // Call the action goal execution function provided.
     if (this.#actionCallback) {
-      this.#actionCallback(rosbridgeRequest.args, id);
+      if (rosbridgeRequest.args) {
+        this.#actionCallback(rosbridgeRequest.args, id);
+      } else {
+        throw new Error(
+          "Received Action goal with no arguments! This should never happen, because rosbridge should fill in blanks!",
+        );
+      }
     }
   }
 

--- a/src/core/Param.ts
+++ b/src/core/Param.ts
@@ -49,8 +49,7 @@ export default class Param<T = unknown> {
         if (result.successful === false) {
           failedCallback(result.reason);
         } else {
-          const value = JSON.parse(result.value);
-          callback(value);
+          callback(JSON.parse(result.value) as T);
         }
       },
       failedCallback,

--- a/src/core/Param.ts
+++ b/src/core/Param.ts
@@ -46,7 +46,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (!result.successful) {
+        if ("successful" in result && !result.successful) {
           failedCallback(result.reason);
         } else {
           callback(JSON.parse(result.value) as T);
@@ -84,7 +84,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (!result.successful) {
+        if ("successful" in result && !result.successful) {
           failedCallback(result.reason);
         } else if (callback) {
           callback(result);
@@ -119,7 +119,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (!result.successful) {
+        if ("successful" in result && !result.successful) {
           failedCallback(result.reason);
         } else {
           callback(result);

--- a/src/core/Param.ts
+++ b/src/core/Param.ts
@@ -46,7 +46,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful === false) {
+        if (!result.successful) {
           failedCallback(result.reason);
         } else {
           callback(JSON.parse(result.value) as T);
@@ -84,7 +84,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful === false) {
+        if (!result.successful) {
           failedCallback(result.reason);
         } else if (callback) {
           callback(result);
@@ -119,7 +119,7 @@ export default class Param<T = unknown> {
     paramClient.callService(
       request,
       function (result) {
-        if (result.successful === false) {
+        if (!result.successful) {
           failedCallback(result.reason);
         } else {
           callback(result);

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -693,7 +693,7 @@ export default class Ros extends EventEmitter<
         const arrayLen = theType.fieldarraylen[i];
         const fieldName = theType.fieldnames[i];
         const fieldType = theType.fieldtypes[i];
-        if (fieldType.indexOf("/") === -1) {
+        if (!fieldType.includes("/")) {
           // check the fieldType includes '/' or not
           if (arrayLen === -1) {
             typeDefDict[fieldName] = fieldType;

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -247,11 +247,11 @@ export default class Ros extends EventEmitter<
    *
    * @param message - The message to be sent.
    */
-  callOnConnection = <TMessage extends RosbridgeMessage>(message: TMessage) => {
+  callOnConnection = (message: unknown) => {
     if (this.transportOptions.encoder) {
-      this.transportOptions.encoder(message, (msg) =>
-        this.sendEncodedMessage(msg),
-      );
+      this.transportOptions.encoder(message, (msg) => {
+        this.sendEncodedMessage(msg);
+      });
     } else {
       this.sendEncodedMessage(JSON.stringify(message));
     }
@@ -704,7 +704,7 @@ export default class Ros extends EventEmitter<
           // lookup the name
           let sub: boolean | rosapi.TypeDef = false;
           for (const hint of hints) {
-            if (hint.type.toString() === fieldType.toString()) {
+            if (hint.type === fieldType) {
               sub = hint;
               break;
             }

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -25,6 +25,10 @@ import SimpleActionServer from "../actionlib/SimpleActionServer.js";
 import { EventEmitter } from "eventemitter3";
 import { rosapi } from "../types/rosapi.ts";
 
+function isRTCPeerDataChannel(obj: unknown): obj is RTCPeerConnection {
+  return obj?.constructor.name === "RTCDataChannel";
+}
+
 /**
  * Manages connection to the server and all interactions with ROS.
  *
@@ -48,7 +52,13 @@ export default class Ros extends EventEmitter<
   idCounter = 0;
   isConnected = false;
   transportLibrary: "websocket" | RTCPeerConnection;
-  transportOptions;
+  transportOptions: {
+    decoder?: (message: unknown) => unknown;
+    encoder?: (
+      message: unknown,
+      callback: (encodedMessage: string) => void,
+    ) => unknown;
+  };
   /**
    * @param [options]
    * @param [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.
@@ -71,7 +81,7 @@ export default class Ros extends EventEmitter<
 
     // begin by checking if a URL was given
     if (url) {
-      this.connect(url);
+      this.connect(url).catch(console.error);
     }
   }
   /**
@@ -82,14 +92,14 @@ export default class Ros extends EventEmitter<
   async #createTransport(
     url: string,
   ): Promise<WebSocket | RTCDataChannel | import("ws").WebSocket | null> {
-    if (this.transportLibrary.constructor.name === "RTCPeerConnection") {
-      // @ts-expect-error -- this is kinda wild. `this.transportLibrary` can either be a string or an RTCDataChannel. This needs fixing.
+    if (isRTCPeerDataChannel(this.transportLibrary)) {
       const dataChannel = this.transportLibrary.createDataChannel(
         url,
+        // @ts-expect-error -- why are the options for an RTC channel conflated with the options for roslibjs's bespoke socket adapter??
         this.transportOptions,
       );
       return dataChannel;
-    } else if (this.transportLibrary === "websocket") {
+    } else {
       // browsers, Deno, and Bun support WebSockets natively
       if (typeof WebSocket === "function") {
         if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
@@ -108,8 +118,6 @@ export default class Ros extends EventEmitter<
         }
         return null; // Already connected
       }
-    } else {
-      throw "Unknown transportLibrary: " + this.transportLibrary.toString();
     }
   }
 
@@ -133,7 +141,7 @@ export default class Ros extends EventEmitter<
         this.emit("close", event);
       },
       onError: (event) => {
-        this.emit("error", String(event));
+        this.emit("error", String(event.error));
       },
       onMessage: (message) => {
         this.#handleMessage(message);
@@ -239,13 +247,15 @@ export default class Ros extends EventEmitter<
    *
    * @param message - The message to be sent.
    */
-  callOnConnection<TMessage extends RosbridgeMessage>(message: TMessage) {
+  callOnConnection = <TMessage extends RosbridgeMessage>(message: TMessage) => {
     if (this.transportOptions.encoder) {
-      this.transportOptions.encoder(message, this.sendEncodedMessage);
+      this.transportOptions.encoder(message, (msg) =>
+        this.sendEncodedMessage(msg),
+      );
     } else {
       this.sendEncodedMessage(JSON.stringify(message));
     }
-  }
+  };
   /**
    * Send a set_level request to the server.
    *
@@ -673,7 +683,10 @@ export default class Ros extends EventEmitter<
    * @param defs - Array of type_def dictionary.
    */
   decodeTypeDefs(defs: rosapi.TypeDef[]) {
-    const decodeTypeDefsRec = (theType, hints) => {
+    const decodeTypeDefsRec = (
+      theType: rosapi.TypeDef,
+      hints: rosapi.TypeDef[],
+    ) => {
       // calls itself recursively to resolve type definition using hints.
       const typeDefDict = {};
       for (let i = 0; i < theType.fieldnames.length; i++) {
@@ -689,7 +702,7 @@ export default class Ros extends EventEmitter<
           }
         } else {
           // lookup the name
-          let sub = false;
+          let sub: boolean | rosapi.TypeDef = false;
           for (const hint of hints) {
             if (hint.type.toString() === fieldType.toString()) {
               sub = hint;

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -152,7 +152,7 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
         });
         this.isAdvertised = true;
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         this.emit("error", err);
         throw err;
       });
@@ -203,7 +203,7 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
       .then(() => {
         this.#doUnadvertise();
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         this.emit("error", err);
         throw err;
       });
@@ -255,7 +255,7 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
         });
         this.isAdvertised = true;
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         this.emit("error", err);
         throw err;
       });

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -19,9 +19,7 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
    * Stores a reference to the most recent service callback advertised so it can be removed from the EventEmitter during un-advertisement
    */
   #serviceCallback:
-    | ((
-        rosbridgeRequest: RosbridgeCallServiceMessage<TRequest>,
-      ) => void | Promise<void>)
+    | ((rosbridgeRequest: RosbridgeCallServiceMessage<TRequest>) => void)
     | null = null;
   isAdvertised = false;
   /**
@@ -112,10 +110,10 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
   ): Promise<void> {
     // Queue this operation to prevent race conditions
     this.#operationQueue = this.#operationQueue
-      .then(async () => {
+      .then(() => {
         // If already advertised, unadvertise first
         if (this.isAdvertised) {
-          await this.#doUnadvertise();
+          this.#doUnadvertise();
         }
 
         // Store the new callback for removal during un-advertisement
@@ -165,7 +163,7 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
   /**
    * Internal method to perform unadvertisement without queueing
    */
-  async #doUnadvertise() {
+  #doUnadvertise() {
     if (!this.isAdvertised || this.#pendingUnadvertise) {
       return;
     }
@@ -202,8 +200,8 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
   async unadvertise(): Promise<void> {
     // Queue this operation to prevent race conditions
     this.#operationQueue = this.#operationQueue
-      .then(async () => {
-        await this.#doUnadvertise();
+      .then(() => {
+        this.#doUnadvertise();
       })
       .catch((err) => {
         this.emit("error", err);
@@ -222,30 +220,32 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
   ): Promise<void> {
     // Queue this operation to prevent race conditions
     this.#operationQueue = this.#operationQueue
-      .then(async () => {
+      .then(() => {
         // If already advertised, unadvertise first
         if (this.isAdvertised) {
-          await this.#doUnadvertise();
+          this.#doUnadvertise();
         }
 
-        this.#serviceCallback = async (rosbridgeRequest) => {
-          try {
-            this.ros.callOnConnection({
-              op: "service_response",
-              service: this.name,
-              result: true,
-              values: await callback(rosbridgeRequest.args),
-              id: rosbridgeRequest.id,
-            } satisfies RosbridgeServiceResponseMessage<TResponse>);
-          } catch (err) {
-            this.ros.callOnConnection({
-              op: "service_response",
-              service: this.name,
-              result: false,
-              values: String(err),
-              id: rosbridgeRequest.id,
-            } satisfies RosbridgeServiceResponseMessage<TResponse>);
-          }
+        this.#serviceCallback = (rosbridgeRequest) => {
+          (async () => {
+            try {
+              this.ros.callOnConnection({
+                op: "service_response",
+                service: this.name,
+                result: true,
+                values: await callback(rosbridgeRequest.args),
+                id: rosbridgeRequest.id,
+              } satisfies RosbridgeServiceResponseMessage<TResponse>);
+            } catch (err) {
+              this.ros.callOnConnection({
+                op: "service_response",
+                service: this.name,
+                result: false,
+                values: String(err),
+                id: rosbridgeRequest.id,
+              } satisfies RosbridgeServiceResponseMessage<TResponse>);
+            }
+          })().catch(console.error);
         };
         this.ros.on(this.name, this.#serviceCallback);
         this.ros.callOnConnection({

--- a/src/core/SocketAdapter.ts
+++ b/src/core/SocketAdapter.ts
@@ -9,6 +9,17 @@ import {
 } from "../types/protocol.js";
 import { deserialize } from "bson";
 
+export type RequiredSocketInterface = Pick<
+  WebSocket | RTCDataChannel | import("ws").WebSocket,
+  | "onmessage"
+  | "onclose"
+  | "onerror"
+  | "onopen"
+  | "readyState"
+  | "send"
+  | "close"
+>;
+
 /**
  * Socket adapter that provides unified event handling for WebSocket and RTCDataChannel.
  * Handles transport-level concerns like fragmentation, encoding/decoding, and delegates
@@ -19,7 +30,7 @@ import { deserialize } from "bson";
 export default class SocketAdapter {
   onOpenCallback: (event: Event) => void;
   onCloseCallback: (event: Event) => void;
-  onErrorCallback: (event: Event) => void;
+  onErrorCallback: (event: ErrorEvent) => void;
   onMessageCallback: (message: RosbridgeMessage) => void;
   decoder:
     | ((data: unknown, callback: (message: RosbridgeMessage) => void) => void)
@@ -41,7 +52,7 @@ export default class SocketAdapter {
    * @param [options.decoder] - Optional decoder function
    */
   constructor(
-    private socket: WebSocket | RTCDataChannel | import("ws").WebSocket,
+    private socket: RequiredSocketInterface,
     {
       onOpen,
       onClose,
@@ -51,9 +62,9 @@ export default class SocketAdapter {
     }: {
       onOpen: (event: Event) => void;
       onClose: (event: Event) => void;
-      onError: (event: Event) => void;
+      onError: (event: ErrorEvent) => void;
       onMessage: (message: RosbridgeMessage) => void;
-      decoder: ((data, callback: (error, result) => void) => void) | null;
+      decoder?: ((data, callback: (error, result) => void) => void) | null;
     },
   ) {
     this.onOpenCallback = onOpen;
@@ -64,7 +75,7 @@ export default class SocketAdapter {
 
     this.socket.onopen = (e: Event) => onOpen(e);
     this.socket.onclose = (e: Event) => onClose(e);
-    this.socket.onerror = (e: Event) => onError(e);
+    this.socket.onerror = (e: ErrorEvent) => onError(e);
     this.socket.onmessage = (e: MessageEvent) => this.onmessage(e);
   }
 
@@ -113,7 +124,7 @@ export default class SocketAdapter {
     // If all integer fragments received, reconstruct and process
     if (entry.received === totalInt) {
       const fullData = entry.fragments.join("");
-      let message;
+      let message: unknown;
       try {
         message = JSON.parse(fullData);
       } catch {
@@ -122,7 +133,11 @@ export default class SocketAdapter {
         return;
       }
       this.fragmentBuffer.delete(id);
-      this.handleMessage(message);
+      if (isRosbridgeMessage(message)) {
+        this.handleMessage(message);
+      } else {
+        throw new Error("Received invalid rosbridge message!");
+      }
     }
   }
 
@@ -133,18 +148,18 @@ export default class SocketAdapter {
     if (isRosbridgePngMessage(message)) {
       // If in Node.js..
       if (typeof window === "undefined") {
-        import("../util/decompressPng.js").then(
-          ({ default: decompressPng }) => {
+        import("../util/decompressPng.js")
+          .then(({ default: decompressPng }) => {
             decompressPng(message.data, callback);
-          },
-        );
+          })
+          .catch(console.error);
       } else {
         // if in browser..
-        import("../util/shim/decompressPng.js").then(
-          ({ default: decompressPng }) => {
+        import("../util/shim/decompressPng.js")
+          .then(({ default: decompressPng }) => {
             decompressPng(message.data, callback);
-          },
-        );
+          })
+          .catch(console.error);
       }
     } else {
       callback(message);
@@ -208,14 +223,25 @@ export default class SocketAdapter {
       });
     } else if (typeof Blob !== "undefined" && data.data instanceof Blob) {
       this.decodeBSON(data.data, (message) => {
-        this.handlePng(message, this.handleMessage.bind(this));
+        this.handlePng(message, (msg) => this.handleMessage(msg));
       });
     } else if (data.data instanceof ArrayBuffer) {
       const decoded = CBOR.decode(data.data, typedArrayTagger);
-      this.handleMessage(decoded);
+      if (isRosbridgeMessage(decoded)) {
+        this.handleMessage(decoded);
+      } else {
+        throw new Error("Received invalid rosbridge message!");
+      }
     } else {
-      const message = JSON.parse(typeof data === "string" ? data : data.data);
-      this.handlePng(message, this.handleMessage.bind(this));
+      const message: unknown = JSON.parse(
+        String(typeof data === "string" ? data : data.data),
+      );
+
+      if (isRosbridgeMessage(message)) {
+        this.handlePng(message, (msg) => this.handleMessage(msg));
+      } else {
+        throw new Error("Received invalid rosbridge message!");
+      }
     }
   }
 }

--- a/src/core/SocketAdapter.ts
+++ b/src/core/SocketAdapter.ts
@@ -73,10 +73,18 @@ export default class SocketAdapter {
     this.onMessageCallback = onMessage;
     this.decoder = decoder;
 
-    this.socket.onopen = (e: Event) => onOpen(e);
-    this.socket.onclose = (e: Event) => onClose(e);
-    this.socket.onerror = (e: ErrorEvent) => onError(e);
-    this.socket.onmessage = (e: MessageEvent) => this.onmessage(e);
+    this.socket.onopen = (e: Event) => {
+      onOpen(e);
+    };
+    this.socket.onclose = (e: Event) => {
+      onClose(e);
+    };
+    this.socket.onerror = (e: ErrorEvent) => {
+      onError(e);
+    };
+    this.socket.onmessage = (e: MessageEvent) => {
+      this.onmessage(e);
+    };
   }
 
   handleMessage(message: RosbridgeMessage) {
@@ -223,7 +231,9 @@ export default class SocketAdapter {
       });
     } else if (typeof Blob !== "undefined" && data.data instanceof Blob) {
       this.decodeBSON(data.data, (message) => {
-        this.handlePng(message, (msg) => this.handleMessage(msg));
+        this.handlePng(message, (msg) => {
+          this.handleMessage(msg);
+        });
       });
     } else if (data.data instanceof ArrayBuffer) {
       const decoded = CBOR.decode(data.data, typedArrayTagger);
@@ -238,7 +248,9 @@ export default class SocketAdapter {
       );
 
       if (isRosbridgeMessage(message)) {
-        this.handlePng(message, (msg) => this.handleMessage(msg));
+        this.handlePng(message, (msg) => {
+          this.handleMessage(msg);
+        });
       } else {
         throw new Error("Received invalid rosbridge message!");
       }

--- a/src/core/Topic.ts
+++ b/src/core/Topic.ts
@@ -127,7 +127,8 @@ export default class Topic<T> extends EventEmitter<{
         this.ros.on("close", this.reconnectFunc);
       };
     } else {
-      this.callForSubscribeAndAdvertise = this.ros.callOnConnection;
+      this.callForSubscribeAndAdvertise = (msg) =>
+        this.ros.callOnConnection(msg);
     }
   }
 

--- a/src/core/Topic.ts
+++ b/src/core/Topic.ts
@@ -23,8 +23,8 @@ import { rosapi } from "../types/rosapi.ts";
 export default class Topic<T> extends EventEmitter<{
   message: [T];
   warning: [string];
-  unsubscribe: void;
-  unadvertise: void;
+  unsubscribe: undefined;
+  unadvertise: undefined;
 }> {
   waitForReconnect: boolean | undefined = undefined;
   reconnectFunc: (() => void) | undefined = undefined;
@@ -106,7 +106,10 @@ export default class Topic<T> extends EventEmitter<{
 
     // Check if throttle rate is negative
     if (this.throttle_rate < 0) {
-      this.emit("warning", this.throttle_rate + " is not allowed. Set to 0");
+      this.emit(
+        "warning",
+        this.throttle_rate.toString() + " is not allowed. Set to 0",
+      );
       this.throttle_rate = 0;
     }
 
@@ -127,8 +130,9 @@ export default class Topic<T> extends EventEmitter<{
         this.ros.on("close", this.reconnectFunc);
       };
     } else {
-      this.callForSubscribeAndAdvertise = (msg) =>
+      this.callForSubscribeAndAdvertise = (msg) => {
         this.ros.callOnConnection(msg);
+      };
     }
   }
 
@@ -250,7 +254,7 @@ export default class Topic<T> extends EventEmitter<{
     this.ros.idCounter++;
     const call = {
       op: "publish",
-      id: "publish:" + this.name + ":" + this.ros.idCounter,
+      id: "publish:" + this.name + ":" + this.ros.idCounter.toString(),
       topic: this.name,
       msg: message,
       latch: this.latch,

--- a/src/tf/BaseTFClient.ts
+++ b/src/tf/BaseTFClient.ts
@@ -76,7 +76,7 @@ export default class BaseTFClient {
   processTFArray(tf: tf2_msgs.TFMessage) {
     tf.transforms.forEach((transform) => {
       let frameID = transform.child_frame_id;
-      if (frameID[0] === "/") {
+      if (frameID.startsWith("/")) {
         frameID = frameID.substring(1);
       }
       const info = this.frameInfos[frameID];
@@ -143,7 +143,7 @@ export default class BaseTFClient {
     }
     const info = this.frameInfos[frameID];
     // eslint-disable-next-line no-var -- literally what even is going on here
-    for (var cbs = info?.cbs || [], idx = cbs.length; idx--; ) {
+    for (var cbs = info?.cbs ?? [], idx = cbs.length; idx--; ) {
       if (cbs[idx] === callback) {
         cbs.splice(idx, 1);
       }

--- a/src/tf/BaseTFClient.ts
+++ b/src/tf/BaseTFClient.ts
@@ -117,7 +117,7 @@ export default class BaseTFClient {
         cbs: [],
       };
       if (!this.republisherUpdateRequested) {
-        setTimeout(this.updateGoal.bind(this), this.updateDelay);
+        setTimeout(() => this.updateGoal(), this.updateDelay);
         this.republisherUpdateRequested = true;
       }
     }

--- a/src/tf/BaseTFClient.ts
+++ b/src/tf/BaseTFClient.ts
@@ -86,7 +86,9 @@ export default class BaseTFClient {
           rotation: transform.transform.rotation,
         });
         info.transform = tf;
-        info.cbs.forEach((cb) => cb(tf));
+        info.cbs.forEach((cb) => {
+          cb(tf);
+        });
       }
     }, this);
   }
@@ -117,7 +119,9 @@ export default class BaseTFClient {
         cbs: [],
       };
       if (!this.republisherUpdateRequested) {
-        setTimeout(() => this.updateGoal(), this.updateDelay);
+        setTimeout(() => {
+          this.updateGoal();
+        }, this.updateDelay);
         this.republisherUpdateRequested = true;
       }
     }
@@ -149,6 +153,7 @@ export default class BaseTFClient {
       }
     }
     if (!callback || cbs.length === 0) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- TODO: refactor this to not cause runtime errors if you have a frame like "prototype" that would make JavaScript explode if you deleted it from an object
       delete this.frameInfos[frameID];
     }
   }

--- a/src/tf/TFClient.ts
+++ b/src/tf/TFClient.ts
@@ -76,9 +76,9 @@ export default class TFClient extends BaseTFClient {
       goalMessage: goalMessage,
     });
 
-    this.currentGoal.on("feedback", (feedback) =>
-      this.processTFArray(feedback),
-    );
+    this.currentGoal.on("feedback", (feedback) => {
+      this.processTFArray(feedback);
+    });
     this.currentGoal.send();
 
     this.republisherUpdateRequested = false;
@@ -112,7 +112,9 @@ export default class TFClient extends BaseTFClient {
       name: response.topic_name,
       messageType: "tf2_web_republisher/TFArray",
     });
-    this.#subscribeCB = (response) => this.processTFArray(response);
+    this.#subscribeCB = (response) => {
+      this.processTFArray(response);
+    };
     this.currentTopic.subscribe(this.#subscribeCB);
   }
 

--- a/src/tf/TFClient.ts
+++ b/src/tf/TFClient.ts
@@ -16,9 +16,17 @@ import BaseTFClient from "./BaseTFClient.js";
  * A TF Client that listens to TFs from tf2_web_republisher.
  */
 export default class TFClient extends BaseTFClient {
-  currentGoal: Goal<tf2_web_republisher.TFSubscriptionGoal> | false = false;
+  currentGoal:
+    | Goal<
+        tf2_web_republisher.TFSubscriptionGoal,
+        tf2_web_republisher.TFSubscriptionFeedback
+      >
+    | false = false;
   currentTopic: Topic<tf2_msgs.TFMessage> | false = false;
-  actionClient: ActionClient<tf2_web_republisher.TFSubscriptionGoal>;
+  actionClient: ActionClient<
+    tf2_web_republisher.TFSubscriptionGoal,
+    tf2_web_republisher.TFSubscriptionFeedback
+  >;
   #subscribeCB: ((tf: tf2_msgs.TFMessage) => void) | undefined = undefined;
   #isDisposed = false;
 
@@ -63,12 +71,14 @@ export default class TFClient extends BaseTFClient {
     if (this.currentGoal) {
       this.currentGoal.cancel();
     }
-    this.currentGoal = new Goal<tf2_web_republisher.TFSubscriptionGoal>({
+    this.currentGoal = new Goal({
       actionClient: this.actionClient,
       goalMessage: goalMessage,
     });
 
-    this.currentGoal.on("feedback", this.processTFArray.bind(this));
+    this.currentGoal.on("feedback", (feedback) =>
+      this.processTFArray(feedback),
+    );
     this.currentGoal.send();
 
     this.republisherUpdateRequested = false;
@@ -102,8 +112,7 @@ export default class TFClient extends BaseTFClient {
       name: response.topic_name,
       messageType: "tf2_web_republisher/TFArray",
     });
-    this.#subscribeCB = this.processTFArray.bind(this);
-    // @ts-expect-error Function was bound above
+    this.#subscribeCB = (response) => this.processTFArray(response);
     this.currentTopic.subscribe(this.#subscribeCB);
   }
 

--- a/src/types/cbor-js.d.ts
+++ b/src/types/cbor-js.d.ts
@@ -1,0 +1,6 @@
+declare module "cbor-js" {
+  function decode(
+    data: ArrayBufferLike,
+    tagger: (data: Uint8Array, tag: number) => unknown,
+  ): unknown;
+}

--- a/src/types/pngparse.d.ts
+++ b/src/types/pngparse.d.ts
@@ -1,0 +1,3 @@
+declare module "pngparse" {
+  function parse(data: Buffer, cb: (err: string, data: unknown) => void);
+}

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -219,7 +219,7 @@ export function isRosbridgeUnadvertiseActionMessage(
 export interface RosbridgeSendActionGoalMessage<TArgs = unknown>
   extends RosbridgeMessage {
   op: "send_action_goal";
-  id?: string;
+  id: string;
   action: string;
   action_type: string;
   args?: TArgs;

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -5,7 +5,11 @@ export interface RosbridgeMessage {
 export function isRosbridgeMessage(
   message: unknown,
 ): message is RosbridgeMessage {
-  return message instanceof Object && typeof message["op"] === "string";
+  return (
+    message instanceof Object &&
+    "op" in message &&
+    typeof message.op === "string"
+  );
 }
 
 export interface RosbridgeStatusMessage extends RosbridgeMessage {

--- a/src/types/rosapi.ts
+++ b/src/types/rosapi.ts
@@ -30,34 +30,56 @@ export namespace rosapi {
     name: string;
     default?: string;
   }
-  interface GetParamResponseFailed {
+  interface GetParamResponsePreJazzy {
+    value: string;
+  }
+  interface GetParamResponseFailedPostJazzy {
     value: never;
     successful: false;
     reason: string;
   }
-  interface GetParamResponseSuccess {
+  interface GetParamResponseSuccessPostJazzy {
     value: string;
     successful: true;
     reason: never;
   }
   export type GetParamResponse =
-    | GetParamResponseFailed
-    | GetParamResponseSuccess;
+    | GetParamResponsePreJazzy
+    | GetParamResponseFailedPostJazzy
+    | GetParamResponseSuccessPostJazzy;
   export interface SetParamRequest {
     name: string;
     value: string;
   }
-  export interface SetParamResponse {
-    successful: boolean;
+  type SetParamResponsePreJazzy = Record<never, never>;
+  interface FailedSetParamResponsePostJazzy {
+    successful: false;
     reason: string;
   }
+  interface SuccessfulSetParamResponsePostJazzy {
+    successful: true;
+    reason: never;
+  }
+  export type SetParamResponse =
+    | SetParamResponsePreJazzy
+    | FailedSetParamResponsePostJazzy
+    | SuccessfulSetParamResponsePostJazzy;
   export interface DeleteParamRequest {
     name: string;
   }
-  export interface DeleteParamResponse {
-    successful: boolean;
+  type DeleteParamResponsePreJazzy = Record<never, never>;
+  interface FailedDeleteParamResponsePostJazzy {
+    successful: false;
     reason: string;
   }
+  interface SuccessfulDeleteParamResponsePostJazzy {
+    successful: true;
+    reason: never;
+  }
+  export type DeleteParamResponse =
+    | DeleteParamResponsePreJazzy
+    | FailedDeleteParamResponsePostJazzy
+    | SuccessfulDeleteParamResponsePostJazzy;
   export type GetActionServersRequest = Record<never, never>;
   export interface GetActionServersResponse {
     action_servers: string[];

--- a/src/util/cborTypedArrayTags.ts
+++ b/src/util/cborTypedArrayTags.ts
@@ -24,7 +24,7 @@ function decodeUint64LE(bytes: Uint8Array) {
   const buffer = bytes.buffer.slice(offset, offset + byteLen);
   const uint32View = new Uint32Array(buffer);
 
-  const arr = new Array(arrLen);
+  const arr = new Array<number>(arrLen);
   for (let i = 0; i < arrLen; i++) {
     const si = i * 2;
     const lo = uint32View[si];
@@ -50,7 +50,7 @@ function decodeInt64LE(bytes: Uint8Array) {
   const uint32View = new Uint32Array(buffer);
   const int32View = new Int32Array(buffer);
 
-  const arr = new Array(arrLen);
+  const arr = new Array<number>(arrLen);
   for (let i = 0; i < arrLen; i++) {
     const si = i * 2;
     const lo = uint32View[si];
@@ -66,12 +66,25 @@ function decodeInt64LE(bytes: Uint8Array) {
  * @param bytes
  * @param ArrayType - Desired output array type
  */
-function decodeNativeArray(bytes: Uint8Array, ArrayType: ArrayConstructor) {
+function decodeNativeArray(
+  bytes: Uint8Array<ArrayBuffer>,
+  ArrayType: TypedArrayConstructor,
+) {
   const byteLen = bytes.byteLength;
   const offset = bytes.byteOffset;
   const buffer = bytes.buffer.slice(offset, offset + byteLen);
   return new ArrayType(buffer);
 }
+
+type TypedArrayConstructor =
+  | Uint8ArrayConstructor
+  | Uint16ArrayConstructor
+  | Uint32ArrayConstructor
+  | Int8ArrayConstructor
+  | Int16ArrayConstructor
+  | Int32ArrayConstructor
+  | Float32ArrayConstructor
+  | Float64ArrayConstructor;
 
 /**
  * Supports a subset of draft CBOR typed array tags:
@@ -79,7 +92,7 @@ function decodeNativeArray(bytes: Uint8Array, ArrayType: ArrayConstructor) {
  *
  * Only supports little-endian tags for now.
  */
-const nativeArrayTypes = {
+const nativeArrayTypes: Record<number, TypedArrayConstructor> = {
   64: Uint8Array,
   69: Uint16Array,
   70: Uint32Array,
@@ -93,7 +106,7 @@ const nativeArrayTypes = {
 /**
  * We can also decode 64-bit integer arrays, since ROS has these types.
  */
-const conversionArrayTypes = {
+const conversionArrayTypes: Record<number, (bytes: Uint8Array) => number[]> = {
   71: decodeUint64LE,
   79: decodeInt64LE,
 };
@@ -103,7 +116,10 @@ const conversionArrayTypes = {
  * @param data
  * @param tag
  */
-export default function cborTypedArrayTagger(data: Uint8Array, tag: number) {
+export default function cborTypedArrayTagger(
+  data: Uint8Array<ArrayBuffer>,
+  tag: number,
+) {
   if (tag in nativeArrayTypes) {
     const arrayType = nativeArrayTypes[tag];
     return decodeNativeArray(data, arrayType);

--- a/src/util/decompressPng.ts
+++ b/src/util/decompressPng.ts
@@ -20,10 +20,10 @@ export default function decompressPng(
   const buffer = new Buffer(data, "base64");
 
   pngparse.parse(buffer, function (err, data) {
-    if (err) {
-      console.warn("Cannot process PNG encoded message ");
+    if (err || !(data instanceof Object) || !("data" in data)) {
+      throw new Error("Cannot process PNG encoded message ");
     } else {
-      const jsonData = data.data.toString();
+      const jsonData = String(data.data);
       callback(JSON.parse(jsonData));
     }
   });

--- a/src/util/decompressPng.ts
+++ b/src/util/decompressPng.ts
@@ -17,7 +17,7 @@ export default function decompressPng(
   data: string,
   callback: (data: unknown) => void,
 ) {
-  const buffer = new Buffer(data, "base64");
+  const buffer = Buffer.from(data, "base64");
 
   pngparse.parse(buffer, function (err, data) {
     if (err || !(data instanceof Object) || !("data" in data)) {

--- a/test/SocketAdapter.test.ts
+++ b/test/SocketAdapter.test.ts
@@ -1,15 +1,23 @@
 import { it, describe, expect, beforeEach, vi } from "vitest";
-import SocketAdapter from "../src/core/SocketAdapter.js";
+import SocketAdapter, {
+  RequiredSocketInterface,
+} from "../src/core/SocketAdapter.js";
+import { Ros } from "../src/index.js";
+import {
+  isRosbridgePublishMessage,
+  RosbridgeMessage,
+} from "../src/types/protocol.js";
 
 describe("SocketAdapter fragment handling", () => {
-  let client;
-  let adapter;
-  let mockSocket;
+  let client: Pick<Ros, "emit" | "transportOptions" | "isConnected">;
+  let adapter: SocketAdapter;
+  let mockSocket: RequiredSocketInterface;
 
   beforeEach(() => {
     client = {
       emit: vi.fn(),
       transportOptions: {},
+      isConnected: false,
     };
 
     // Create mock WebSocket
@@ -24,21 +32,21 @@ describe("SocketAdapter fragment handling", () => {
     };
 
     const options = {
-      onOpen: (event) => {
+      onOpen: (event: Event) => {
         client.isConnected = true;
         client.emit("connection", event);
       },
-      onClose: (event) => {
+      onClose: (event: Event) => {
         client.isConnected = false;
         client.emit("close", event);
       },
-      onError: (event) => {
-        client.emit("error", event);
+      onError: (event: ErrorEvent) => {
+        client.emit("error", String(event.error));
       },
-      onMessage: (message) => {
+      onMessage: (message: RosbridgeMessage) => {
         // Simulate Ros.js message handling
-        if (message.op === "publish") {
-          client.emit(message.topic, message.msg);
+        if (isRosbridgePublishMessage(message)) {
+          client.emit(message.topic, message);
         }
       },
     };
@@ -47,9 +55,10 @@ describe("SocketAdapter fragment handling", () => {
     vi.clearAllMocks();
   });
 
-  function sendFragment(id, total, fragments) {
+  function sendFragment(id: string, total: number, fragments: unknown[]) {
     for (let i = 0; i < fragments.length; i++) {
       // Simulate socket receiving a message
+      // @ts-expect-error -- mock unhappy about `this` context mismatch
       mockSocket.onmessage({
         data: JSON.stringify({
           op: "fragment",
@@ -69,7 +78,7 @@ describe("SocketAdapter fragment handling", () => {
     const json = JSON.stringify(msg);
     const fragments = [json.slice(0, 10), json.slice(10, 20), json.slice(20)];
     sendFragment(id, total, fragments);
-    expect(client.emit).toHaveBeenCalledWith("foo", { data: 42 });
+    expect(client.emit).toHaveBeenCalledWith("foo", msg);
     expect(client.emit).toHaveBeenCalledTimes(1);
   });
 
@@ -80,7 +89,7 @@ describe("SocketAdapter fragment handling", () => {
     const json = JSON.stringify(msg);
     const fragments = [json.slice(0, 10), json.slice(10)];
     sendFragment(id, total, fragments);
-    expect(client.emit).toHaveBeenCalledWith("bar", { data: 99 });
+    expect(client.emit).toHaveBeenCalledWith("bar", msg);
     expect(client.emit).toHaveBeenCalledTimes(1);
   });
 
@@ -91,7 +100,7 @@ describe("SocketAdapter fragment handling", () => {
     const json = JSON.stringify(msg);
     const fragments = [json.slice(0, 10), json.slice(10), "extra"];
     sendFragment(id, total, fragments);
-    expect(client.emit).toHaveBeenCalledWith("baz", { data: 7 });
+    expect(client.emit).toHaveBeenCalledWith("baz", msg);
     expect(client.emit).toHaveBeenCalledTimes(1);
   });
 
@@ -106,7 +115,8 @@ describe("SocketAdapter fragment handling", () => {
   });
 
   it("ignores malformed fragments", () => {
-    mockSocket.onmessage({
+    // @ts-expect-error -- mock unhappy about `this` context mismatch
+    mockSocket.onmessage?.({
       data: JSON.stringify({ op: "fragment", id: "bad" }),
     });
     expect(client.emit).not.toHaveBeenCalled();
@@ -114,22 +124,28 @@ describe("SocketAdapter fragment handling", () => {
 
   describe("socket event handling", () => {
     it("handles socket open event", () => {
-      mockSocket.onopen({ type: "open" });
+      // @ts-expect-error -- mock unhappy about `this` context mismatch
+      mockSocket.onopen?.({ type: "open" });
       expect(client.isConnected).toBe(true);
       expect(client.emit).toHaveBeenCalledWith("connection", { type: "open" });
     });
 
     it("handles socket close event", () => {
       client.isConnected = true;
-      mockSocket.onclose({ type: "close" });
+      // @ts-expect-error -- mock unhappy about `this` context mismatch
+      mockSocket.onclose?.({ type: "close" });
       expect(client.isConnected).toBe(false);
       expect(client.emit).toHaveBeenCalledWith("close", { type: "close" });
     });
 
     it("handles socket error event", () => {
-      const errorEvent = { type: "error", message: "Connection failed" };
-      mockSocket.onerror(errorEvent);
-      expect(client.emit).toHaveBeenCalledWith("error", errorEvent);
+      const errorEvent = { error: new Error("Connection failed") };
+      // @ts-expect-error -- mock unhappy about `this` context mismatch
+      mockSocket.onerror?.(errorEvent);
+      expect(client.emit).toHaveBeenCalledWith(
+        "error",
+        "Error: Connection failed",
+      );
     });
   });
 
@@ -141,6 +157,7 @@ describe("SocketAdapter fragment handling", () => {
     });
 
     it("does not send data when socket is closed", () => {
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
       mockSocket.readyState = 3; // WebSocket.CLOSED
       const testData = "test message";
       adapter.send(testData);
@@ -153,6 +170,7 @@ describe("SocketAdapter fragment handling", () => {
     });
 
     it("returns socket readyState", () => {
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
       mockSocket.readyState = 2; // WebSocket.CLOSING
       expect(adapter.readyState).toBe(2);
     });

--- a/test/cbor.test.ts
+++ b/test/cbor.test.ts
@@ -3,8 +3,11 @@ import CBOR from "cbor-js";
 import cborTypedArrayTagger from "../src/util/cborTypedArrayTags.js";
 
 /** Convert hex string to ArrayBuffer. */
-function hexToBuffer(hex) {
+function hexToBuffer(hex: string) {
   const tokens = hex.match(/[0-9a-fA-F]{2}/gi);
+  if (!tokens) {
+    throw new Error("No tokens matched!");
+  }
   const arr = tokens.map(function (t) {
     return parseInt(t, 16);
   });
@@ -16,7 +19,9 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("d84546010002000300");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Uint16Array");
+    if (!(msg instanceof Uint16Array)) {
+      throw new Error("Expected Uint16Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(2);
@@ -27,7 +32,9 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("d8464c010000000200000003000000");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Uint32Array");
+    if (!(msg instanceof Uint32Array)) {
+      throw new Error("Expected Uint32Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(2);
@@ -40,7 +47,9 @@ describe("CBOR Typed Array Tagger", function () {
     );
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Array");
+    if (!Array.isArray(msg)) {
+      throw new Error("Expected Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(2);
@@ -51,7 +60,9 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("d8484301fe03");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Int8Array");
+    if (!(msg instanceof Int8Array)) {
+      throw new Error("Expected Int8Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(-2);
@@ -62,7 +73,9 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("d84d460100feff0300");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Int16Array");
+    if (!(msg instanceof Int16Array)) {
+      throw new Error("Expected Int16Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(-2);
@@ -73,7 +86,9 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("d84e4c01000000feffffff03000000");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Int32Array");
+    if (!(msg instanceof Int32Array)) {
+      throw new Error("Expected Int32Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(-2);
@@ -86,7 +101,9 @@ describe("CBOR Typed Array Tagger", function () {
     );
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Array");
+    if (!Array.isArray(msg)) {
+      throw new Error("Expected Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.equal(1);
     expect(msg[1]).to.equal(-2);
@@ -97,7 +114,9 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("d8554ccdcc8c3fcdcc0cc033335340");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Float32Array");
+    if (!(msg instanceof Float32Array)) {
+      throw new Error("Expected Float32Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.be.closeTo(1.1, 1e-5);
     expect(msg[1]).to.be.closeTo(-2.2, 1e-5);
@@ -110,7 +129,9 @@ describe("CBOR Typed Array Tagger", function () {
     );
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Float64Array");
+    if (!(msg instanceof Float64Array)) {
+      throw new Error("Expected Float64Array");
+    }
     expect(msg).to.have.lengthOf(3);
     expect(msg[0]).to.be.closeTo(1.1, 1e-5);
     expect(msg[1]).to.be.closeTo(-2.2, 1e-5);
@@ -121,7 +142,15 @@ describe("CBOR Typed Array Tagger", function () {
     const data = hexToBuffer("82d8484308fe05d84d460100feff0300");
     const msg = CBOR.decode(data, cborTypedArrayTagger);
 
-    expect(msg).to.be.a("Array");
+    if (!Array.isArray(msg)) {
+      throw new Error("Expected Array");
+    }
+    if (!(msg[0] instanceof Int8Array)) {
+      throw new Error("Expected Int8Array");
+    }
+    if (!(msg[1] instanceof Int16Array)) {
+      throw new Error("Expected Int16Array");
+    }
     expect(msg).to.have.lengthOf(2);
     expect(msg[0][0]).to.equal(8);
     expect(msg[0][1]).to.equal(-2);

--- a/test/examples/check-topics.example.ts
+++ b/test/examples/check-topics.example.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import * as ROSLIB from "../../src/RosLib.js";
+import { rosapi } from "../../src/types/rosapi.js";
 
 const expectedTopics = ["/listener"];
 
@@ -9,13 +10,14 @@ describe("Example topics are live", function () {
   });
 
   it("getTopics", async () => {
-    const callback = vi.fn();
+    const callback = vi.fn((res: rosapi.TopicsResponse) => {
+      for (const topic of expectedTopics) {
+        expect(res.topics).to.contain(topic);
+      }
+    });
     ros.getTopics(callback);
     await vi.waitFor(() => {
       expect(callback).toHaveBeenCalledOnce();
-      for (const topic of expectedTopics) {
-        expect(callback.mock.calls[0][0].topics).to.contain(topic);
-      }
     });
   });
 
@@ -25,33 +27,35 @@ describe("Example topics are live", function () {
   });
 
   it("doesn't automatically advertise the topic", async () => {
-    const callback = vi.fn();
+    const callback = vi.fn((res: rosapi.TopicsResponse) => {
+      expect(res.topics).not.to.contain("/some_test_topic");
+    });
     ros.getTopics(callback);
     await vi.waitFor(() => {
       expect(callback).toHaveBeenCalledOnce();
-      expect(callback.mock.calls[0][0].topics).not.to.contain(
-        "/some_test_topic",
-      );
     });
     example.advertise();
   });
 
   it("advertise broadcasts the topic", async () => {
-    const callback = vi.fn();
+    const callback = vi.fn((res: rosapi.TopicsResponse) => {
+      expect(res.topics).to.contain("/some_test_topic");
+    });
     ros.getTopics(callback);
     await vi.waitFor(() => {
       expect(callback).toHaveBeenCalledOnce();
-      expect(callback.mock.calls[0][0].topics).to.contain("/some_test_topic");
     });
     example.unadvertise();
   });
 
   it("unadvertise will end the topic (if it's the last around)", async () => {
-    const callback = vi.fn();
-    ros.getTopics(callback);
-    vi.waitFor(function () {
-      expect(callback).toHaveBeenCalledOnce();
-      expect(callback.mock.calls[0][0]).not.to.contain("/some_test_topic");
+    const callback = vi.fn<(res: rosapi.TopicsResponse) => void>();
+    await vi.waitFor(function () {
+      ros.getTopics(callback);
+      expect(callback).toHaveBeenCalled();
+      expect(callback.mock.calls.at(-1)?.at(0)?.topics).not.to.contain(
+        "/some_test_topic",
+      );
     }, 15000);
-  });
+  }, 15000);
 });

--- a/test/examples/params.example.ts
+++ b/test/examples/params.example.ts
@@ -60,7 +60,7 @@ describe("Param setting", function () {
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
     const getParamsCallback = vi.fn();
     ros.getParams(getParamsCallback);
-    vi.waitFor(() =>
+    await vi.waitFor(() =>
       expect(getParamsCallback.mock.calls[0][0]).to.not.include(PARAM_NAME),
     );
   });

--- a/test/examples/params.example.ts
+++ b/test/examples/params.example.ts
@@ -27,19 +27,25 @@ describe("Param setting", function () {
   it("Param.get", { retry: 3 }, async () => {
     const callback = vi.fn();
     param.get(callback);
-    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(true));
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(true);
+    });
   });
 
   it("Param.set w/ callback", async () => {
     const callback = vi.fn();
     param.set(false, callback);
-    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalled();
+    });
   });
 
   it("Param.get", async () => {
     const callback = vi.fn();
     param.get(callback);
-    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(false));
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(false);
+    });
   });
 
   // Known issue with getting params being able to hang in Humble because it had no timeout.
@@ -57,7 +63,9 @@ describe("Param setting", function () {
   it.skipIf(process.env.ROS_DISTRO !== "noetic")("Param.delete", async () => {
     const callback = vi.fn();
     param.delete(callback);
-    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalled();
+    });
     const getParamsCallback = vi.fn();
     ros.getParams(getParamsCallback);
     await vi.waitFor(() =>

--- a/test/examples/pubsub.example.ts
+++ b/test/examples/pubsub.example.ts
@@ -32,8 +32,9 @@ describe("Topics Example", function () {
         return; // Skip our own published message
       }
 
-      if (messages1Copy.length) {
-        example.publish(messages1Copy.shift()!);
+      const nextMessage = messages1Copy.shift();
+      if (nextMessage) {
+        example.publish(nextMessage);
       }
     });
 
@@ -42,15 +43,17 @@ describe("Topics Example", function () {
         return; // Skip our own published message
       }
 
-      if (messages2Copy.length) {
-        example2.publish(messages2Copy.shift()!);
+      const nextMessage = messages2Copy.shift();
+      if (nextMessage) {
+        example2.publish(nextMessage);
       }
     });
 
     example.subscribe(example1Callback);
     example2.subscribe(example2Callback);
 
-    // Start the conversation
+    // Start the conversationc
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- this is the first shift, we know it's there
     example.publish(messages1Copy.shift()!);
 
     // Wait for all expected calls to complete

--- a/test/examples/tf.example.ts
+++ b/test/examples/tf.example.ts
@@ -8,8 +8,9 @@ describe.skipIf(process.env.ROS_DISTRO !== "noetic")(
   function () {
     it("tf republisher", () =>
       new Promise<void>((done) => {
-        const ros = new ROSLIB.Ros();
-        ros.connect("ws://localhost:9090");
+        const ros = new ROSLIB.Ros({
+          url: "ws://localhost:9090",
+        });
 
         const tfClient = new ROSLIB.TFClient({
           ros: ros,

--- a/test/examples/topic-listener.example.ts
+++ b/test/examples/topic-listener.example.ts
@@ -5,13 +5,13 @@ const ros = new ROSLIB.Ros({
   url: "ws://localhost:9090",
 });
 
-function format(msg) {
+function format(msg: string) {
   return { data: msg };
 }
 const messages = ["1", "2", "3", "4"].map(format);
 
 describe("Topics Example", function () {
-  function createAndStreamTopic(topicName) {
+  function createAndStreamTopic(topicName: string) {
     const topic = ros.Topic({
       name: topicName,
       messageType: "std_msgs/String",

--- a/test/math-examples.test.ts
+++ b/test/math-examples.test.ts
@@ -1,19 +1,12 @@
 import { describe, it, expect } from "vitest";
 import * as ROSLIB from "../src/RosLib.js";
 
-function clone(x) {
-  const y = {};
-  for (const prop in x) {
-    if (Object.prototype.hasOwnProperty.call(x, prop)) {
-      y[prop] = typeof x[prop] === "object" ? clone(x[prop]) : x[prop];
-    }
-  }
-  return y;
-}
-
 describe("Math examples", function () {
-  let v1, q1, v2, q2;
-  let pos;
+  let v1: ROSLIB.Vector3,
+    q1: ROSLIB.Quaternion,
+    v2: ROSLIB.Vector3,
+    q2: ROSLIB.Quaternion;
+  let pos: ROSLIB.Pose;
   it("Vector3 example", function () {
     // Let's start by adding some vectors.
     v1 = new ROSLIB.Vector3({
@@ -26,7 +19,7 @@ describe("Math examples", function () {
     expect(v1).eql(v2);
 
     v1.add(v2);
-    expect(clone(v1)).eql({
+    expect(v1.clone()).eql({
       x: 2,
       y: 4,
       z: 6,
@@ -59,7 +52,7 @@ describe("Math examples", function () {
       position: v1,
       orientation: q1,
     });
-    expect(clone(pos)).to.eql(clone({ position: v1, orientation: q1 }));
+    expect(pos.clone()).to.eql({ position: v1, orientation: q1 });
   });
 
   it("Transform example", function () {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, expect, vi } from "vitest";
-import { Service, Ros } from "../";
+import { Service, Ros } from "../src/RosLib";
 
 describe("Service", () => {
   const ros = new Ros({

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -12,12 +12,12 @@ describe("Service", () => {
       serviceType: "std_srvs/Trigger",
       name: "/test_service",
     });
-    await server.advertiseAsync(async () => {
-      return {
+    await server.advertiseAsync(async () =>
+      Promise.resolve({
         success: true,
         message: "foo",
-      };
-    });
+      }),
+    );
     const client = new Service({
       ros,
       serviceType: "std_srvs/Trigger",
@@ -140,22 +140,22 @@ describe("Service", () => {
     });
 
     // First advertisement
-    await server.advertiseAsync(async () => {
-      return {
+    await server.advertiseAsync(async () =>
+      Promise.resolve({
         success: true,
         message: "first",
-      };
-    });
+      }),
+    );
 
     expect(server.isAdvertised).toBe(true);
 
     // Re-advertise with different callback - should not throw
-    await server.advertiseAsync(async () => {
-      return {
+    await server.advertiseAsync(async () =>
+      Promise.resolve({
         success: true,
         message: "second",
-      };
-    });
+      }),
+    );
 
     expect(server.isAdvertised).toBe(true);
 

--- a/test/setup/ros-backend.ts
+++ b/test/setup/ros-backend.ts
@@ -89,7 +89,7 @@ async function buildContainer(rosDistro: string) {
 /**
  * Start the ROS backend container
  */
-async function startContainer(rosDistro) {
+async function startContainer(rosDistro: string) {
   console.log("Starting ROS backend container...");
 
   // Stop and remove existing container if it exists
@@ -112,7 +112,7 @@ async function startContainer(rosDistro) {
   });
 
   await container.start();
-  console.log(`Container started on port ${CONTAINER_PORT}`);
+  console.log(`Container started on port ${CONTAINER_PORT.toString()}`);
 }
 
 /**
@@ -126,7 +126,7 @@ async function waitForBackend() {
   while (Date.now() - startTime < MAX_WAIT_TIME) {
     try {
       await waitForRosConnection(
-        new Ros({ url: `ws://localhost:${CONTAINER_PORT}` }),
+        new Ros({ url: `ws://localhost:${CONTAINER_PORT.toString()}` }),
       );
       console.log("ROS backend is ready");
       return true;

--- a/test/setup/ros-backend.ts
+++ b/test/setup/ros-backend.ts
@@ -17,6 +17,7 @@ const docker = new Docker();
  * Get ROS distro from environment or default to noetic
  */
 function getRosDistro() {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- this might be an empty string, not undefined.
   return process.env.ROS_DISTRO || "noetic";
 }
 

--- a/test/setup/ros-backend.ts
+++ b/test/setup/ros-backend.ts
@@ -20,7 +20,7 @@ function getRosDistro() {
   return process.env.ROS_DISTRO || "noetic";
 }
 
-async function waitForRosConnection(ros, timeout = 5000) {
+async function waitForRosConnection(ros: Ros, timeout = 5000) {
   return new Promise<void>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       reject(new Error("Timeout waiting for ROS connection"));
@@ -33,7 +33,7 @@ async function waitForRosConnection(ros, timeout = 5000) {
 
     ros.on("error", (error) => {
       clearTimeout(timeoutId);
-      reject(error);
+      reject(new Error(error));
     });
 
     // If already connected
@@ -47,7 +47,7 @@ async function waitForRosConnection(ros, timeout = 5000) {
 /**
  * Build the ROS test container
  */
-async function buildContainer(rosDistro) {
+async function buildContainer(rosDistro: string) {
   console.log(`Building ROS test container for ${rosDistro}...`);
 
   const stream = await docker.buildImage(
@@ -72,7 +72,7 @@ async function buildContainer(rosDistro) {
           resolve(res);
         }
       },
-      (event) => {
+      (event: { stream?: Uint8Array; errorDetail?: { message: string } }) => {
         if (event.stream) {
           process.stdout.write(event.stream);
         } else if (event.errorDetail) {
@@ -149,7 +149,7 @@ async function stopContainer() {
     await container.remove();
     console.log("Container stopped");
   } catch (error) {
-    console.error("Error stopping container:", error.message);
+    console.error("Error stopping container:", String(error));
   }
 }
 
@@ -162,7 +162,7 @@ async function getLogs() {
     const logs = await container.logs({ stdout: true, stderr: true });
     return logs.toString();
   } catch (error) {
-    return `Error getting logs: ${error.message}`;
+    return `Error getting logs: ${String(error)}`;
   }
 }
 


### PR DESCRIPTION
Bumped typescript-eslint all the way up to "strict", which found lots of weirdness. Some I introduced during the TypeScript port, some that already existed and needed to be annotated correctly.

Fixed it all.

Not sure if we'll keep it at strict in the long term (because that might make it hard for non-TypeScript-experts to contribute), we could bump it down to "recommended type checked" later, but I think having it be strict for awhile might be a good thing to try.