### PR TITLE
Enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(
       // Plenty of APIs (like mocking APIs in Vitest) require empty functions to be declared.
       "@typescript-eslint/no-empty-function": 0,
       "prefer-template": 2,
+      "@typescript-eslint/consistent-type-imports": 2,
     },
   },
   {

--- a/src/actionlib/ActionClient.ts
+++ b/src/actionlib/ActionClient.ts
@@ -3,11 +3,11 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-import Ros from "../core/Ros.js";
+import type Ros from "../core/Ros.js";
 import Topic from "../core/Topic.js";
 import { EventEmitter } from "eventemitter3";
-import { actionlib_msgs } from "../types/actionlib_msgs.js";
-import Goal from "./Goal.js";
+import type { actionlib_msgs } from "../types/actionlib_msgs.js";
+import type Goal from "./Goal.js";
 
 /**
  * An actionlib action client.

--- a/src/actionlib/ActionListener.ts
+++ b/src/actionlib/ActionListener.ts
@@ -4,10 +4,10 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-import Ros from "../core/Ros.js";
+import type Ros from "../core/Ros.js";
 import Topic from "../core/Topic.js";
 import { EventEmitter } from "eventemitter3";
-import { actionlib_msgs } from "../types/actionlib_msgs.js";
+import type { actionlib_msgs } from "../types/actionlib_msgs.js";
 
 /**
  * An actionlib action listener.

--- a/src/actionlib/Goal.ts
+++ b/src/actionlib/Goal.ts
@@ -4,8 +4,8 @@
  */
 
 import { EventEmitter } from "eventemitter3";
-import ActionClient from "./ActionClient";
-import { actionlib_msgs } from "../types/actionlib_msgs";
+import type ActionClient from "./ActionClient";
+import type { actionlib_msgs } from "../types/actionlib_msgs";
 import { v4 as uuidv4 } from "uuid";
 
 /**

--- a/src/actionlib/SimpleActionServer.ts
+++ b/src/actionlib/SimpleActionServer.ts
@@ -3,11 +3,11 @@
  * @author Laura Lindzey - lindzey@gmail.com
  */
 
-import Ros from "../core/Ros.js";
+import type Ros from "../core/Ros.js";
 import Topic from "../core/Topic.js";
 import { EventEmitter } from "eventemitter3";
-import { actionlib_msgs } from "../types/actionlib_msgs.js";
-import { std_msgs } from "../types/std_msgs.js";
+import type { actionlib_msgs } from "../types/actionlib_msgs.js";
+import type { std_msgs } from "../types/std_msgs.js";
 
 /**
  * An actionlib action server client.

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -4,14 +4,14 @@
  */
 
 import { GoalStatus } from "./GoalStatus.ts";
+import type { RosbridgeSendActionGoalMessage } from "../types/protocol.ts";
 import {
   isRosbridgeActionFeedbackMessage,
   isRosbridgeActionResultMessage,
   isRosbridgeCancelActionGoalMessage,
   isRosbridgeSendActionGoalMessage,
-  RosbridgeSendActionGoalMessage,
 } from "../types/protocol.ts";
-import Ros from "./Ros.js";
+import type Ros from "./Ros.js";
 import { v4 as uuidv4 } from "uuid";
 
 /**

--- a/src/core/Param.ts
+++ b/src/core/Param.ts
@@ -3,8 +3,8 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-import { rosapi } from "../types/rosapi.js";
-import Ros from "./Ros.js";
+import type { rosapi } from "../types/rosapi.js";
+import type Ros from "./Ros.js";
 import Service from "./Service.js";
 
 /**

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -4,6 +4,7 @@
  */
 
 import socketAdapter from "./SocketAdapter.js";
+import type { RosbridgeMessage } from "../types/protocol.js";
 import {
   isRosbridgeActionFeedbackMessage,
   isRosbridgeActionResultMessage,
@@ -13,7 +14,6 @@ import {
   isRosbridgeSendActionGoalMessage,
   isRosbridgeServiceResponseMessage,
   isRosbridgeStatusMessage,
-  RosbridgeMessage,
 } from "../types/protocol.js";
 
 import Topic from "./Topic.js";
@@ -23,7 +23,8 @@ import TFClient from "../tf/TFClient";
 import ActionClient from "../actionlib/ActionClient.js";
 import SimpleActionServer from "../actionlib/SimpleActionServer.js";
 import { EventEmitter } from "eventemitter3";
-import { rosapi } from "../types/rosapi.ts";
+import type { rosapi } from "../types/rosapi.ts";
+import type { WebSocket as WsWebSocket } from "ws";
 
 function isRTCPeerDataChannel(obj: unknown): obj is RTCPeerConnection {
   return obj?.constructor.name === "RTCDataChannel";
@@ -47,8 +48,7 @@ export default class Ros extends EventEmitter<
     // Any dynamically-named event should correspond to a rosbridge protocol message
   } & Record<string, [RosbridgeMessage]>
 > {
-  /** @type {import('./SocketAdapter.js').default | null} */
-  socket: import("./SocketAdapter.js").default | null = null;
+  socket: socketAdapter | null = null;
   isConnected = false;
   transportLibrary: "websocket" | RTCPeerConnection;
   transportOptions: {
@@ -90,7 +90,7 @@ export default class Ros extends EventEmitter<
    */
   async #createTransport(
     url: string,
-  ): Promise<WebSocket | RTCDataChannel | import("ws").WebSocket | null> {
+  ): Promise<WebSocket | RTCDataChannel | WsWebSocket | null> {
     if (isRTCPeerDataChannel(this.transportLibrary)) {
       const dataChannel = this.transportLibrary.createDataChannel(
         url,

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -4,12 +4,12 @@
  */
 
 import { EventEmitter } from "eventemitter3";
-import {
-  isRosbridgeServiceResponseMessage,
+import type {
   RosbridgeCallServiceMessage,
   RosbridgeServiceResponseMessage,
 } from "../types/protocol.ts";
-import Ros from "./Ros.js";
+import { isRosbridgeServiceResponseMessage } from "../types/protocol.ts";
+import type Ros from "./Ros.js";
 import { v4 as uuidv4 } from "uuid";
 
 /**

--- a/src/core/SocketAdapter.ts
+++ b/src/core/SocketAdapter.ts
@@ -1,16 +1,19 @@
 import CBOR from "cbor-js";
 import typedArrayTagger from "../util/cborTypedArrayTags.js";
+import type {
+  RosbridgeFragmentMessage,
+  RosbridgeMessage,
+} from "../types/protocol.js";
 import {
   isRosbridgeFragmentMessage,
   isRosbridgeMessage,
   isRosbridgePngMessage,
-  RosbridgeFragmentMessage,
-  RosbridgeMessage,
 } from "../types/protocol.js";
 import { deserialize } from "bson";
+import type { WebSocket as WsWebSocket } from "ws";
 
 export type RequiredSocketInterface = Pick<
-  WebSocket | RTCDataChannel | import("ws").WebSocket,
+  WebSocket | RTCDataChannel | WsWebSocket,
   | "onmessage"
   | "onclose"
   | "onerror"

--- a/src/core/Topic.ts
+++ b/src/core/Topic.ts
@@ -5,13 +5,13 @@
 
 import { EventEmitter } from "eventemitter3";
 import Service from "./Service.js";
-import Ros from "./Ros.js";
-import {
+import type Ros from "./Ros.js";
+import type {
   RosbridgeAdvertiseMessage,
   RosbridgePublishMessage,
   RosbridgeSubscribeMessage,
 } from "../types/protocol.ts";
-import { rosapi } from "../types/rosapi.ts";
+import type { rosapi } from "../types/rosapi.ts";
 import { v4 as uuidv4 } from "uuid";
 
 /**

--- a/src/math/Pose.ts
+++ b/src/math/Pose.ts
@@ -5,7 +5,7 @@
 import Vector3, { type IVector3 } from "./Vector3.js";
 import Quaternion, { type IQuaternion } from "./Quaternion.js";
 import { type ITransform } from "./Transform.js";
-import { PartialNullable } from "../types/interface-types.js";
+import type { PartialNullable } from "../types/interface-types.js";
 
 export interface IPose {
   /**

--- a/src/tf/BaseTFClient.ts
+++ b/src/tf/BaseTFClient.ts
@@ -1,7 +1,7 @@
 import Transform from "../math/Transform.js";
-import Ros from "../core/Ros.js";
-import { tf2_msgs } from "../types/tf2_msgs.js";
-import { std_msgs } from "../types/std_msgs.js";
+import type Ros from "../core/Ros.js";
+import type { tf2_msgs } from "../types/tf2_msgs.js";
+import type { std_msgs } from "../types/std_msgs.js";
 
 /**
  * Base class for TF Clients that provides common functionality.

--- a/src/tf/ROS2TFClient.ts
+++ b/src/tf/ROS2TFClient.ts
@@ -1,4 +1,4 @@
-import { tf2_web_republisher } from "../types/tf2_web_republisher.js";
+import type { tf2_web_republisher } from "../types/tf2_web_republisher.js";
 import Action from "../core/Action.js";
 import BaseTFClient from "./BaseTFClient.js";
 

--- a/src/tf/TFClient.ts
+++ b/src/tf/TFClient.ts
@@ -7,8 +7,8 @@ import ActionClient from "../actionlib/ActionClient.js";
 import Goal from "../actionlib/Goal.js";
 
 import Topic from "../core/Topic.js";
-import { tf2_msgs } from "../types/tf2_msgs.js";
-import { tf2_web_republisher } from "../types/tf2_web_republisher.js";
+import type { tf2_msgs } from "../types/tf2_msgs.js";
+import type { tf2_web_republisher } from "../types/tf2_web_republisher.js";
 
 import BaseTFClient from "./BaseTFClient.js";
 

--- a/src/types/actionlib_msgs.ts
+++ b/src/types/actionlib_msgs.ts
@@ -1,5 +1,5 @@
-import { std_msgs } from "./std_msgs.js";
-import { GoalStatus as GoalStatusEnum } from "../core/GoalStatus.js";
+import type { std_msgs } from "./std_msgs.js";
+import type { GoalStatus as GoalStatusEnum } from "../core/GoalStatus.js";
 
 export namespace actionlib_msgs {
   export interface GoalID {

--- a/src/types/tf2_msgs.ts
+++ b/src/types/tf2_msgs.ts
@@ -1,4 +1,4 @@
-import { geometry_msgs } from "./geometry_msgs";
+import type { geometry_msgs } from "./geometry_msgs";
 
 export namespace tf2_msgs {
   export interface TFMessage {

--- a/src/types/tf2_web_republisher.ts
+++ b/src/types/tf2_web_republisher.ts
@@ -1,5 +1,5 @@
-import { geometry_msgs } from "./geometry_msgs";
-import { std_msgs } from "./std_msgs";
+import type { geometry_msgs } from "./geometry_msgs";
+import type { std_msgs } from "./std_msgs";
 
 export namespace tf2_web_republisher {
   export interface RepublishTFsRequest extends TFSubscriptionGoal {

--- a/src/urdf/UrdfModel.ts
+++ b/src/urdf/UrdfModel.ts
@@ -4,7 +4,8 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-import { DOMParser, Element, MIME_TYPE } from "@xmldom/xmldom";
+import type { Element } from "@xmldom/xmldom";
+import { DOMParser, MIME_TYPE } from "@xmldom/xmldom";
 import UrdfMaterial from "./UrdfMaterial.js";
 import UrdfLink from "./UrdfLink.js";
 import UrdfJoint from "./UrdfJoint.js";

--- a/src/urdf/UrdfTypes.ts
+++ b/src/urdf/UrdfTypes.ts
@@ -1,4 +1,4 @@
-import { Element } from "@xmldom/xmldom";
+import type { Element } from "@xmldom/xmldom";
 
 export enum UrdfType {
   SPHERE = 0,

--- a/src/urdf/UrdfUtils.ts
+++ b/src/urdf/UrdfUtils.ts
@@ -1,5 +1,5 @@
 /********** Utility Methods for parsing Joint **********/
-import { Element, Node } from "@xmldom/xmldom";
+import type { Element, Node } from "@xmldom/xmldom";
 import { Pose, Quaternion, Vector3 } from "../math/index.js";
 import { UrdfAttrs } from "./UrdfTypes.js";
 

--- a/src/urdf/UrdfVisual.ts
+++ b/src/urdf/UrdfVisual.ts
@@ -4,7 +4,7 @@
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-import { Element } from "@xmldom/xmldom";
+import type { Element } from "@xmldom/xmldom";
 import Pose from "../math/Pose.js";
 import UrdfCylinder from "./UrdfCylinder.js";
 import UrdfBox from "./UrdfBox.js";

--- a/test/SocketAdapter.test.ts
+++ b/test/SocketAdapter.test.ts
@@ -1,12 +1,9 @@
 import { it, describe, expect, beforeEach, vi } from "vitest";
-import SocketAdapter, {
-  RequiredSocketInterface,
-} from "../src/core/SocketAdapter.js";
-import { Ros } from "../src/index.js";
-import {
-  isRosbridgePublishMessage,
-  RosbridgeMessage,
-} from "../src/types/protocol.js";
+import type { RequiredSocketInterface } from "../src/core/SocketAdapter.js";
+import SocketAdapter from "../src/core/SocketAdapter.js";
+import type { Ros } from "../src/index.js";
+import type { RosbridgeMessage } from "../src/types/protocol.js";
+import { isRosbridgePublishMessage } from "../src/types/protocol.js";
 
 describe("SocketAdapter fragment handling", () => {
   let client: Pick<Ros, "emit" | "transportOptions" | "isConnected">;

--- a/test/examples/check-topics.example.ts
+++ b/test/examples/check-topics.example.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import * as ROSLIB from "../../src/RosLib.js";
-import { rosapi } from "../../src/types/rosapi.js";
+import type { rosapi } from "../../src/types/rosapi.js";
 
 const expectedTopics = ["/listener"];
 


### PR DESCRIPTION
This makes sure bundlers (Vite, in our case) know that they can drop the import in the resulting JS if it was only used for type-checking and isn't used at runtime.