### PR TITLE
Add transport factory option to customize the websocket used

### DIFF
--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -35,7 +35,7 @@ export type TransportLibrary =
   | RTCPeerConnection
   | TransportFactory;
 
-export interface RTCTransportOptions extends RTCDataChannelInit {
+export interface TransportOptions extends RTCDataChannelInit {
   /**
    * Hook to handle outgoing socket message and encode it.
    */
@@ -81,7 +81,7 @@ export default class Ros extends EventEmitter<
   socket: SocketAdapter | null = null;
   isConnected = false;
   transportLibrary: TransportLibrary;
-  transportOptions: RTCTransportOptions;
+  transportOptions: TransportOptions;
   /**
    * @param [options]
    * @param [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.
@@ -95,7 +95,7 @@ export default class Ros extends EventEmitter<
   }: {
     url?: string;
     transportLibrary?: TransportLibrary;
-    transportOptions?: RTCTransportOptions;
+    transportOptions?: TransportOptions;
   } = {}) {
     super();
 

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -3,7 +3,8 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-import socketAdapter from "./SocketAdapter.js";
+import type { RequiredSocketInterface } from "./SocketAdapter.js";
+import SocketAdapter from "./SocketAdapter.js";
 import type { RosbridgeMessage } from "../types/protocol.js";
 import {
   isRosbridgeActionFeedbackMessage,
@@ -24,11 +25,40 @@ import ActionClient from "../actionlib/ActionClient.js";
 import SimpleActionServer from "../actionlib/SimpleActionServer.js";
 import { EventEmitter } from "eventemitter3";
 import type { rosapi } from "../types/rosapi.ts";
-import type { WebSocket as WsWebSocket } from "ws";
 
 function isRTCPeerDataChannel(obj: unknown): obj is RTCPeerConnection {
   return obj?.constructor.name === "RTCDataChannel";
 }
+
+export type TransportLibrary =
+  | "websocket"
+  | RTCPeerConnection
+  | TransportFactory;
+
+export interface RTCTransportOptions extends RTCDataChannelInit {
+  /**
+   * Hook to handle outgoing socket message and encode it.
+   */
+  encoder?: (
+    message: unknown,
+    callback: (encodedMessage: string) => void,
+  ) => unknown;
+  /**
+   * Hook to handle incoming socket message and decode it.
+   */
+  decoder?: (message: unknown) => unknown;
+}
+
+/**
+ * Function that is called whenever a new transport is needed.
+ * For example, to connect a websocket to the rosbridge server.
+ */
+export type TransportFactory = (
+  /**
+   * The WebSocket URL for rosbridge.
+   */
+  url: string,
+) => Promise<RequiredSocketInterface>;
 
 /**
  * Manages connection to the server and all interactions with ROS.
@@ -48,21 +78,15 @@ export default class Ros extends EventEmitter<
     // Any dynamically-named event should correspond to a rosbridge protocol message
   } & Record<string, [RosbridgeMessage]>
 > {
-  socket: socketAdapter | null = null;
+  socket: SocketAdapter | null = null;
   isConnected = false;
-  transportLibrary: "websocket" | RTCPeerConnection;
-  transportOptions: {
-    decoder?: (message: unknown) => unknown;
-    encoder?: (
-      message: unknown,
-      callback: (encodedMessage: string) => void,
-    ) => unknown;
-  };
+  transportLibrary: TransportLibrary;
+  transportOptions: RTCTransportOptions;
   /**
    * @param [options]
    * @param [options.url] - The WebSocket URL for rosbridge. Can be specified later with `connect`.
    * @param [options.transportLibrary='websocket'] - 'websocket', or an RTCPeerConnection instance controlling how the connection is created in `connect`.
-   * @param [options.transportOptions={}] - The options to use when creating a connection. Currently only used if `transportLibrary` is RTCPeerConnection.
+   * @param [options.transportOptions={}] - The options to use when creating a connection.
    */
   constructor({
     url,
@@ -70,8 +94,8 @@ export default class Ros extends EventEmitter<
     transportOptions = {},
   }: {
     url?: string;
-    transportLibrary?: "websocket" | RTCPeerConnection;
-    transportOptions?: object;
+    transportLibrary?: TransportLibrary;
+    transportOptions?: RTCTransportOptions;
   } = {}) {
     super();
 
@@ -88,49 +112,59 @@ export default class Ros extends EventEmitter<
    * @param url - WebSocket URL or RTCDataChannel label for rosbridge.
    * @returns The created transport
    */
-  async #createTransport(
-    url: string,
-  ): Promise<WebSocket | RTCDataChannel | WsWebSocket | null> {
+  async #createTransport(url: string): Promise<RequiredSocketInterface> {
     if (isRTCPeerDataChannel(this.transportLibrary)) {
       const dataChannel = this.transportLibrary.createDataChannel(
         url,
-        // @ts-expect-error -- why are the options for an RTC channel conflated with the options for roslibjs's bespoke socket adapter??
         this.transportOptions,
       );
       return dataChannel;
-    } else {
-      // browsers, Deno, and Bun support WebSockets natively
-      if (typeof WebSocket === "function") {
-        if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
-          const sock = new WebSocket(url);
-          sock.binaryType = "arraybuffer";
-          return sock;
-        }
-        return null; // Already connected
-      } else {
-        // if in Node.js, import ws to replace WebSocket API
-        const ws = await import("ws");
-        if (!this.socket || this.socket.readyState === ws.WebSocket.CLOSED) {
-          const sock = new ws.WebSocket(url);
-          sock.binaryType = "arraybuffer";
-          return sock;
-        }
-        return null; // Already connected
-      }
     }
-  }
 
+    // Custom factory function to create a transport.
+    if (typeof this.transportLibrary === "function") {
+      return this.transportLibrary(url);
+    }
+
+    // Browsers, Deno, Bun, and Node 22+ support WebSockets natively
+    if (typeof WebSocket === "function") {
+      const sock = new WebSocket(url);
+      sock.binaryType = "arraybuffer";
+      return sock;
+    }
+
+    // If in Node.js, import ws to replace WebSocket API
+    const ws = await import("ws");
+    const sock = new ws.WebSocket(url);
+    sock.binaryType = "arraybuffer";
+    return sock;
+  }
+  /**
+   * Check if we need to create a new transport.
+   */
+  #checkIfNeedNewTransport(): boolean {
+    // For backwards compatibility, a new RTC transport was always created
+    if (isRTCPeerDataChannel(this.transportLibrary)) {
+      return true;
+    }
+    // Should we create a new transport if the socket is closing, too?
+    if (!this.socket || this.socket.isClosed()) {
+      return true;
+    }
+    // Socket isn't closed, keep using it
+    return false;
+  }
   /**
    * @param url - WebSocket URL or RTCDataChannel label for rosbridge.
    */
   async connect(url: string) {
-    const transport = await this.#createTransport(url);
-
-    if (!transport) {
+    if (!this.#checkIfNeedNewTransport()) {
       return; // Already connected
     }
 
-    this.socket = new socketAdapter(transport, {
+    const transport = await this.#createTransport(url);
+
+    this.socket = new SocketAdapter(transport, {
       onOpen: (event) => {
         this.isConnected = true;
         this.emit("connection", event);

--- a/src/core/SocketAdapter.ts
+++ b/src/core/SocketAdapter.ts
@@ -76,11 +76,11 @@ enum RTCDataChannelReadyState {
  * @class SocketAdapter
  */
 export default class SocketAdapter {
-  private onOpenCallback: (event: Event) => void;
-  private onCloseCallback: (event: Event) => void;
-  private onErrorCallback: (event: ErrorEvent) => void;
-  private onMessageCallback: (message: RosbridgeMessage) => void;
-  private decoder: Decoder | null;
+  onOpenCallback: (event: Event) => void;
+  onCloseCallback: (event: Event) => void;
+  onErrorCallback: (event: ErrorEvent) => void;
+  onMessageCallback: (message: RosbridgeMessage) => void;
+  decoder: Decoder | null;
   /**
    * Buffer Map for incoming message fragments
    */

--- a/src/core/SocketAdapter.ts
+++ b/src/core/SocketAdapter.ts
@@ -24,6 +24,51 @@ export type RequiredSocketInterface = Pick<
 >;
 
 /**
+ * A decoder provides custom decoding logic for socket messages.
+ * The primary use case is for RTC data channel sockets.
+ */
+type Decoder = (
+  /**
+   * The raw message data from the socket.
+   */
+  data: unknown,
+  /**
+   * Invoked with the decoded RosbridgeMessage object.
+   */
+  callback: (message: RosbridgeMessage) => void,
+) => void;
+
+/**
+ * Not all runtimes will have native WebSocket classes or
+ * using the 'ws' package, so can't reliably reference them
+ * so created our own enum for type safety.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/readyState
+ */
+enum WebSocketReadyState {
+  CONNECTING = 0,
+  OPEN = 1,
+  CLOSING = 2,
+  CLOSED = 3,
+}
+
+/**
+ * Not all runtimes will have native WebSocket classes or
+ * using the 'ws' package, so can't reliably reference them
+ * so created our own enum for type safety.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/readyState
+ */
+enum RTCDataChannelReadyState {
+  CONNECTING = "connecting",
+  OPEN = "open",
+  CLOSING = "closing",
+  CLOSED = "closed",
+}
+
+/**
  * Socket adapter that provides unified event handling for WebSocket and RTCDataChannel.
  * Handles transport-level concerns like fragmentation, encoding/decoding, and delegates
  * message processing to provided callbacks.
@@ -31,17 +76,15 @@ export type RequiredSocketInterface = Pick<
  * @class SocketAdapter
  */
 export default class SocketAdapter {
-  onOpenCallback: (event: Event) => void;
-  onCloseCallback: (event: Event) => void;
-  onErrorCallback: (event: ErrorEvent) => void;
-  onMessageCallback: (message: RosbridgeMessage) => void;
-  decoder:
-    | ((data: unknown, callback: (message: RosbridgeMessage) => void) => void)
-    | null;
+  private onOpenCallback: (event: Event) => void;
+  private onCloseCallback: (event: Event) => void;
+  private onErrorCallback: (event: ErrorEvent) => void;
+  private onMessageCallback: (message: RosbridgeMessage) => void;
+  private decoder: Decoder | null;
   /**
    * Buffer Map for incoming message fragments
    */
-  fragmentBuffer = new Map<
+  private fragmentBuffer = new Map<
     string,
     { fragments: string[]; received: number; total: number }
   >();
@@ -67,7 +110,7 @@ export default class SocketAdapter {
       onClose: (event: Event) => void;
       onError: (event: ErrorEvent | RTCErrorEvent) => void;
       onMessage: (message: RosbridgeMessage) => void;
-      decoder?: ((data, callback: (error, result) => void) => void) | null;
+      decoder?: Decoder | null;
     },
   ) {
     this.onOpenCallback = onOpen;
@@ -204,11 +247,7 @@ export default class SocketAdapter {
    * Send data through the socket
    */
   send(data: string | ArrayBuffer | Blob) {
-    // Check readyState for both WebSocket and RTCDataChannel
-    const isOpen =
-      this.socket.readyState === 1 || // WebSocket.OPEN
-      this.socket.readyState === "open"; // RTCDataChannel 'open'
-    if (isOpen) {
+    if (this.isOpen()) {
       // @ts-expect-error -- WebSocket and RTCDataChannel have compatible send methods in practice
       this.socket.send(data);
     }
@@ -225,8 +264,36 @@ export default class SocketAdapter {
    * Get the current connection state
    * @returns The socket ready state
    */
-  get readyState(): number | string {
+  get readyState(): RequiredSocketInterface["readyState"] {
     return this.socket.readyState;
+  }
+
+  isConnecting(): boolean {
+    return (
+      this.readyState === WebSocketReadyState.CONNECTING ||
+      this.readyState === RTCDataChannelReadyState.CONNECTING
+    );
+  }
+
+  isOpen(): boolean {
+    return (
+      this.readyState === WebSocketReadyState.OPEN ||
+      this.readyState === RTCDataChannelReadyState.OPEN
+    );
+  }
+
+  isClosing(): boolean {
+    return (
+      this.readyState === WebSocketReadyState.CLOSING ||
+      this.readyState === RTCDataChannelReadyState.CLOSING
+    );
+  }
+
+  isClosed(): boolean {
+    return (
+      this.readyState === WebSocketReadyState.CLOSED ||
+      this.readyState === RTCDataChannelReadyState.CLOSED
+    );
   }
 
   /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,8 @@
+export type {
+  TransportLibrary,
+  TransportFactory,
+  TransportOptions,
+} from "./Ros.js";
 export { default as Ros } from "./Ros.js";
 export { default as Topic } from "./Topic.js";
 export { default as Param } from "./Param.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,7 @@ export type {
   TransportFactory,
   TransportOptions,
 } from "./Ros.js";
+export type { RequiredSocketInterface } from "./SocketAdapter.js";
 export { default as Ros } from "./Ros.js";
 export { default as Topic } from "./Topic.js";
 export { default as Param } from "./Param.js";

--- a/test/SocketAdapter.test.ts
+++ b/test/SocketAdapter.test.ts
@@ -172,4 +172,74 @@ describe("SocketAdapter fragment handling", () => {
       expect(adapter.readyState).toBe(2);
     });
   });
+
+  describe("readystate helper methods", () => {
+    const assertIsConnecting = () => {
+      expect(adapter.isConnecting()).toBe(true);
+      expect(adapter.isOpen()).toBe(false);
+      expect(adapter.isClosing()).toBe(false);
+      expect(adapter.isClosed()).toBe(false);
+    };
+
+    const assertIsOpen = () => {
+      expect(adapter.isConnecting()).toBe(false);
+      expect(adapter.isOpen()).toBe(true);
+      expect(adapter.isClosing()).toBe(false);
+      expect(adapter.isClosed()).toBe(false);
+    };
+
+    const assertIsClosing = () => {
+      expect(adapter.isConnecting()).toBe(false);
+      expect(adapter.isOpen()).toBe(false);
+      expect(adapter.isClosing()).toBe(true);
+      expect(adapter.isClosed()).toBe(false);
+    };
+
+    const assertIsClosed = () => {
+      expect(adapter.isConnecting()).toBe(false);
+      expect(adapter.isOpen()).toBe(false);
+      expect(adapter.isClosing()).toBe(false);
+      expect(adapter.isClosed()).toBe(true);
+    };
+
+    it("returns true for isConnecting when socket is connecting", () => {
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 0; // WebSocket
+      assertIsConnecting();
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = "connecting" as unknown; // RTCDataChannel
+      assertIsConnecting();
+    });
+
+    it("returns true for isOpen when socket is open", () => {
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 1; // WebSocket
+      assertIsOpen();
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = "open" as unknown; // RTCDataChannel
+      assertIsOpen();
+    });
+
+    it("returns true for isClosing when socket is closing", () => {
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 2; // WebSocket
+      assertIsClosing();
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = "closing" as unknown; // RTCDataChannel
+      assertIsClosing();
+    });
+
+    it("returns true for isClosed when socket is closed", () => {
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 3; // WebSocket
+      assertIsClosed();
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = "closed" as unknown; // RTCDataChannel
+      assertIsClosed();
+    });
+  });
 });

--- a/test/ros.test.ts
+++ b/test/ros.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ROSLIB from "../src/RosLib.js";
+import type { TransportFactory } from "../src/core/Ros.js";
+import type { RequiredSocketInterface } from "../src/core/SocketAdapter.js";
+
+const { mockNativeWebSocketConstructor, mockPackageWebSocketConstructor } =
+  vi.hoisted(() => {
+    return {
+      mockNativeWebSocketConstructor: vi.fn(),
+      mockPackageWebSocketConstructor: vi.fn(),
+    };
+  });
+
+vi.mock("ws", () => {
+  return {
+    WebSocket: MockWsWebSocketClass,
+  };
+});
+
+class MockNativeWebSocketClass {
+  constructor() {
+    return mockNativeWebSocketConstructor();
+  }
+}
+
+class MockWsWebSocketClass {
+  constructor() {
+    return mockPackageWebSocketConstructor();
+  }
+}
+
+describe("Ros", function () {
+  let mockSocket: RequiredSocketInterface;
+  let mockTransportFactory: TransportFactory;
+
+  beforeEach(() => {
+    mockSocket = {
+      onopen: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+      onmessage: vi.fn(),
+      readyState: 1, // WebSocket.OPEN
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+
+    mockNativeWebSocketConstructor.mockReturnValue(mockSocket);
+    mockPackageWebSocketConstructor.mockReturnValue(mockSocket);
+
+    mockTransportFactory = vi
+      .fn<TransportFactory>()
+      .mockResolvedValue(mockSocket);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("#createTransport", () => {
+    it("creates a transport using a factory function", async () => {
+      const mockTransportFactory = vi
+        .fn<TransportFactory>()
+        .mockResolvedValue(mockSocket);
+
+      const ros = new ROSLIB.Ros({
+        transportLibrary: mockTransportFactory,
+      });
+
+      await ros.connect("ws://localhost:9090");
+
+      expect(mockTransportFactory).toHaveBeenCalledWith("ws://localhost:9090");
+    });
+
+    it("does not create a new transport if the socket is not closed", async () => {
+      const ros = new ROSLIB.Ros({
+        transportLibrary: mockTransportFactory,
+      });
+
+      // always creates a new transport the first time
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(1);
+
+      vi.clearAllMocks();
+
+      // socket is open, so no new transport is created
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(0);
+
+      // For good measure, let's test the ready states individually.
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 0; // WebSocket.CONNECTING
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(0);
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 1; // WebSocket.OPEN
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(0);
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 2; // WebSocket.CLOSING
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(0);
+    });
+
+    it("creates a new transport if the socket is closed", async () => {
+      const ros = new ROSLIB.Ros({
+        transportLibrary: mockTransportFactory,
+      });
+
+      // always creates a new transport the first time
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(1);
+
+      vi.clearAllMocks();
+
+      // @ts-expect-error -- normally readonly type being manipulated as a mock
+      mockSocket.readyState = 3; // WebSocket.CLOSED
+      await ros.connect("ws://localhost:9090");
+      expect(mockTransportFactory).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses native WebSocket when available", async () => {
+      vi.stubGlobal("WebSocket", MockNativeWebSocketClass);
+      expect(typeof WebSocket).toBe("function");
+
+      const ros = new ROSLIB.Ros({
+        transportLibrary: "websocket",
+      });
+
+      await ros.connect("ws://localhost:9090");
+
+      expect(mockNativeWebSocketConstructor).toHaveBeenCalledTimes(1);
+      expect(mockPackageWebSocketConstructor).toHaveBeenCalledTimes(0);
+    });
+
+    it("uses ws package WebSocket when native WebSocket is not available", async () => {
+      vi.stubGlobal("WebSocket", undefined);
+      expect(typeof WebSocket).toBe("undefined");
+
+      const ros = new ROSLIB.Ros({
+        transportLibrary: "websocket",
+      });
+
+      await ros.connect("ws://localhost:9090");
+
+      expect(mockNativeWebSocketConstructor).toHaveBeenCalledTimes(0);
+      expect(mockPackageWebSocketConstructor).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

When creating a `new Ros(options)` instance, expanded the transport library option to accept a factory function.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

We recently updated from Node 20 to Node 22 and noticed that the Ros websocket connection behavior was different. If the server was unstable and the socket could not connect immediately, when we were on Node 20 then the Ros websocket would repeatedly try until connected. But on Node 22 there was a single attempt and then the code seemed to hang.

This came down to [Node 22 now ships](https://nodejs.org/en/learn/getting-started/websocket) with a [native WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) impl which behaves differently than the [ws package](https://www.npmjs.com/package/ws).

We would like to continue using the `ws` package rather than the native WebSocket class.

**Example Usage**
```ts
import * as roslib from 'roslib';

// same original behavior
// will use native WebSocket if available else ws package
new roslib.Ros();

// same original behavior
// will use native WebSocket if available else ws package
new roslib.Ros({
  transportLibrary: "websocket",
});

// new opt-in behavior to create your own websocket instance
new roslib.Ros({
  transportLibrary: async (url: string): Promise<roslib.RequiredSocketInterface> => {
    // ...
  },
});

// example using ws package with custom options
import WebSocket from 'ws';

new roslib.Ros({
  transportLibrary: async (url: string): Promise<roslib.RequiredSocketInterface> => {
    return new WebSocket(url, {
      handshakeTimeout: 30_000,
    });
  },
});
```

<!-- Link relevant GitHub issues -->
