### PR TITLE
Stop bundling dependencies, UMD file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "vite": "^7.0.0",
         "vite-plugin-checker": "^0.11.0",
         "vite-plugin-dts": "^4.0.2",
+        "vite-plugin-externalize-deps": "^0.10.0",
         "vitest": "^4.0.3",
         "vitest-fail-on-console": "^0.10.1"
       },
@@ -4473,7 +4474,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -5814,6 +5814,19 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-externalize-deps": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-externalize-deps/-/vite-plugin-externalize-deps-0.10.0.tgz",
+      "integrity": "sha512-eQrtpT/Do7AvDn76l1yL6ZHyXJ+UWH2LaHVqhAes9go54qaAnPZuMbgxcroQ/7WY3ZyetZzYW2quQnDF0DV5qg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/voracious"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/RosLib.umd.cjs",
   "module": "./dist/RosLib.js",
   "exports": {
     ".": {
-      "import": "./dist/RosLib.js",
-      "require": "./dist/RosLib.umd.cjs"
+      "import": "./dist/RosLib.js"
     }
   },
   "type": "module",
@@ -36,6 +34,7 @@
     "vite": "^7.0.0",
     "vite-plugin-checker": "^0.11.0",
     "vite-plugin-dts": "^4.0.2",
+    "vite-plugin-externalize-deps": "^0.10.0",
     "vitest": "^4.0.3",
     "vitest-fail-on-console": "^0.10.1"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { resolve } from "path";
 import { defineConfig } from "vitest/config";
 import dts from "vite-plugin-dts";
 import checker from "vite-plugin-checker";
+import { externalizeDeps } from "vite-plugin-externalize-deps";
 
 export default defineConfig({
   plugins: [
@@ -20,6 +21,7 @@ export default defineConfig({
         useFlatConfig: true,
       },
     }),
+    externalizeDeps(),
   ],
   build: {
     lib: {
@@ -28,16 +30,7 @@ export default defineConfig({
       name: "ROSLIB",
       // the proper extensions will be added
       fileName: "RosLib",
-    },
-    rollupOptions: {
-      /*
-       * make sure to externalize deps that shouldn't be bundled
-       * into your library
-       */
-      external: ["eventemitter3", "ws", "src/util/decompressPng.js"],
-      output: {
-        globals: { eventemitter3: "EventEmitter3" },
-      },
+      formats: ["es"],
     },
     // Keep synchronized with minimum engine specified in CI & package.json
     target: "node18",


### PR DESCRIPTION
Allow users' package managers to satisfy our dependencies, instead of bundling them all in our compiled output.

(this is like dynamic linking as opposed to static linking for JS)

As an aside, the question now becomes "why use a bundler like Vite at all now when we're not really 'bundling' anything?". Why indeed? I ported us to Vite to replace a bunch of old tooling, but maybe we don't even need Vite in the long term since the JavaScript module-importing ecosystem is far more mature than it once was.