### PR TITLE
(actions) correct reference of outputs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -33,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ needs.build.outputs.page_url }}
     permissions:
       actions: read # to read the artifact from the previous job
       # pages and id-token required to deploy to GitHub Pages


### PR DESCRIPTION
The previous implementation seems to work. Though in the GH docs, it is never mentioned you can reference the output of a step from another job. The docs suggest this way of accessing outputs of a step of another job.
