### PR TITLE
Refactor: Exhaustive Bridge Protocol

### DIFF
--- a/src/actionlib/ActionClient.ts
+++ b/src/actionlib/ActionClient.ts
@@ -20,13 +20,13 @@ import type Goal from "./Goal.js";
  *
  */
 export default class ActionClient<
-  TGoal = unknown,
-  TFeedback = unknown,
-  TResult = unknown,
+  TGoal = never,
+  TFeedback = never,
+  TResult = never,
 > extends EventEmitter<{
   timeout: undefined;
 }> {
-  goals: Partial<Record<string, Goal<TGoal>>> = {};
+  goals: Partial<Record<string, Goal<TGoal, TFeedback, TResult>>> = {};
   /** flag to check if a status has been received */
   receivedStatus = false;
   ros: Ros;

--- a/src/actionlib/ActionListener.ts
+++ b/src/actionlib/ActionListener.ts
@@ -20,7 +20,7 @@ import type { actionlib_msgs } from "../types/actionlib_msgs.js";
  *
  */
 export default class ActionListener<
-  TGoal,
+  TGoal extends object,
   TFeedback,
   TResult,
 > extends EventEmitter<{

--- a/src/actionlib/Goal.ts
+++ b/src/actionlib/Goal.ts
@@ -15,9 +15,9 @@ import { v4 as uuidv4 } from "uuid";
  *  * 'timeout' - If a timeout occurred while sending a goal.
  */
 export default class Goal<
-  TGoal,
-  TFeedback = unknown,
-  TResult = unknown,
+  TGoal = never,
+  TFeedback = never,
+  TResult = never,
 > extends EventEmitter<{
   timeout: undefined;
   status: [actionlib_msgs.GoalStatus];

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -139,14 +139,14 @@ export default class Action<
 
     this.#actionCallback = actionCallback;
     this.#cancelCallback = cancelCallback;
-    this.ros.on(this.name, (msg) => {
-      if (isRosbridgeSendActionGoalMessage(msg)) {
-        this.#executeAction.bind(this);
-      } else {
+    this.ros.on(this.name, (msg: AnyActionOp<TGoal, TFeedback, TResult>) => {
+      if (msg.op !== "send_action_goal") {
         throw new Error(
           "Received unrelated message on Action server event stream!",
         );
       }
+
+      this.#executeAction(msg);
     });
     this.ros.callOnConnection({
       op: "advertise_action",

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -4,15 +4,17 @@
  */
 
 import { GoalStatus } from "./GoalStatus.ts";
-import type { RosbridgeSendActionGoalMessage } from "../types/protocol.ts";
-import {
-  isRosbridgeActionFeedbackMessage,
-  isRosbridgeActionResultMessage,
-  isRosbridgeCancelActionGoalMessage,
-  isRosbridgeSendActionGoalMessage,
-} from "../types/protocol.ts";
 import type Ros from "./Ros.js";
 import { v4 as uuidv4 } from "uuid";
+import type { ActionIdString } from "../types/emitted_events.js";
+import type {
+  AnyActionOp,
+  SendActionGoalOp,
+  CancelActionGoalOp,
+  ActionFeedbackOp,
+  ActionResultSuccessOp,
+  ActionResultFailedOp,
+} from "../types/protocol.js";
 
 /**
  * A ROS 2 action client.
@@ -68,21 +70,24 @@ export default class Action<
       return;
     }
 
-    const actionGoalId = `send_action_goal:${this.name}:${uuidv4()}`;
+    const actionGoalId: ActionIdString = `send_action_goal:${this.name}:${uuidv4()}`;
 
-    this.ros.on(actionGoalId, function (message) {
-      if (isRosbridgeActionResultMessage<TResult>(message)) {
-        if (!message.result) {
-          failedCallback(message.values ?? "");
-        } else {
-          resultCallback(message.values);
+    this.ros.on(
+      actionGoalId,
+      (message: AnyActionOp<TGoal, TFeedback, TResult>) => {
+        if (message.op === "action_result") {
+          if (!message.result) {
+            failedCallback(message.values ?? "");
+          } else {
+            resultCallback(message.values);
+          }
+        } else if (message.op === "action_feedback") {
+          feedbackCallback?.(message.values);
         }
-      } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
-        feedbackCallback?.(message.values);
-      }
-    });
+      },
+    );
 
-    const call = {
+    const call: SendActionGoalOp<TGoal> = {
       op: "send_action_goal",
       id: actionGoalId,
       action: this.name,
@@ -101,7 +106,7 @@ export default class Action<
    * @param id - The ID of the action goal to cancel.
    */
   cancelGoal(id: string) {
-    const call = {
+    const call: CancelActionGoalOp = {
       op: "cancel_action_goal",
       id: id,
       action: this.name,
@@ -166,16 +171,13 @@ export default class Action<
    * @param rosbridgeRequest.id - The ID of the action goal.
    * @param rosbridgeRequest.args - The arguments of the action goal.
    */
-  #executeAction(rosbridgeRequest: RosbridgeSendActionGoalMessage<TGoal>) {
+  #executeAction(rosbridgeRequest: SendActionGoalOp<TGoal>) {
     const id = rosbridgeRequest.id;
 
     // If a cancellation callback exists, call it when a cancellation event is emitted.
     if (typeof id === "string") {
-      this.ros.on(id, (message) => {
-        if (
-          isRosbridgeCancelActionGoalMessage(message) &&
-          this.#cancelCallback
-        ) {
+      this.ros.on(id, (message: AnyActionOp<TGoal, TFeedback, TResult>) => {
+        if (message.op === "cancel_action_goal" && this.#cancelCallback) {
           this.#cancelCallback(id);
         }
       });
@@ -183,13 +185,12 @@ export default class Action<
 
     // Call the action goal execution function provided.
     if (this.#actionCallback) {
-      if (rosbridgeRequest.args) {
-        this.#actionCallback(rosbridgeRequest.args, id);
-      } else {
+      if (!rosbridgeRequest.args) {
         throw new Error(
           "Received Action goal with no arguments! This should never happen, because rosbridge should fill in blanks!",
         );
       }
+      this.#actionCallback(rosbridgeRequest.args, id);
     }
   }
 
@@ -200,7 +201,7 @@ export default class Action<
    * @param feedback - The feedback to send.
    */
   sendFeedback(id: string, feedback: TFeedback) {
-    const call = {
+    const call: ActionFeedbackOp<TFeedback> = {
       op: "action_feedback",
       id: id,
       action: this.name,
@@ -216,7 +217,7 @@ export default class Action<
    * @param result - The result to set.
    */
   setSucceeded(id: string, result: TResult) {
-    const call = {
+    const call: ActionResultSuccessOp<TResult> = {
       op: "action_result",
       id: id,
       action: this.name,
@@ -234,7 +235,7 @@ export default class Action<
    * @param result - The result to set.
    */
   setCanceled(id: string, result: TResult) {
-    const call = {
+    const call: ActionResultSuccessOp<TResult> = {
       op: "action_result",
       id: id,
       action: this.name,
@@ -251,7 +252,7 @@ export default class Action<
    * @param id - The action goal ID.
    */
   setFailed(id: string) {
-    const call = {
+    const call: ActionResultFailedOp = {
       op: "action_result",
       id: id,
       action: this.name,

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -16,35 +16,43 @@ import type {
   ActionResultFailedOp,
 } from "../types/protocol.js";
 
+type ActionCallback<TGoal extends object> = (
+  goal: TGoal,
+  id: string | undefined,
+) => void;
+type ActionCancelCallback = (id: string) => void;
+
+interface ActionOptions {
+  /**
+   * The ROSLIB.Ros connection handle.
+   */
+  ros: Ros;
+  /**
+   * The action name, like '/fibonacci'.
+   */
+  name: string;
+  /**
+   * The action type, like 'example_interfaces/Fibonacci'.
+   */
+  actionType: string;
+}
+
 /**
  * A ROS 2 action client.
  */
 export default class Action<
-  TGoal = unknown,
-  TFeedback = unknown,
-  TResult = unknown,
+  TGoal extends object = object,
+  TFeedback extends object = object,
+  TResult extends object = object,
 > {
   isAdvertised = false;
-  #actionCallback: ((goal: TGoal, id: string) => void) | null = null;
-  #cancelCallback: ((id: string) => void) | null = null;
+  #actionCallback: ActionCallback<TGoal> | null = null;
+  #cancelCallback: ActionCancelCallback | null = null;
   ros: Ros;
   name: string;
   actionType: string;
-  /**
-   * @param options
-   * @param options.ros - The ROSLIB.Ros connection handle.
-   * @param options.name - The action name, like '/fibonacci'.
-   * @param options.actionType - The action type, like 'example_interfaces/Fibonacci'.
-   */
-  constructor({
-    ros,
-    name,
-    actionType,
-  }: {
-    ros: Ros;
-    name: string;
-    actionType: string;
-  }) {
+
+  constructor({ ros, name, actionType }: ActionOptions) {
     this.ros = ros;
     this.name = name;
     this.actionType = actionType;
@@ -122,8 +130,8 @@ export default class Action<
    * @param cancelCallback - A callback function to execute when the action is canceled.
    */
   advertise(
-    actionCallback: (goal: TGoal, id: string) => void,
-    cancelCallback: (id: string) => void,
+    actionCallback: ActionCallback<TGoal>,
+    cancelCallback: ActionCancelCallback,
   ) {
     if (this.isAdvertised || typeof actionCallback !== "function") {
       return;

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -32,6 +32,7 @@ import type {
   TransportEvent,
 } from "./transport/Transport.js";
 import { WebSocketTransportFactory } from "./transport/WebSocketTransportFactory.ts";
+import type { RosEventTypes } from "../types/emitted_events.js";
 
 interface TypeDefDict {
   [key: string]: string | string[] | TypeDefDict | TypeDefDict[];
@@ -47,14 +48,7 @@ interface TypeDefDict {
  *  * &#60;topicName&#62; - A message came from rosbridge with the given topic name.
  *  * &#60;serviceID&#62; - A service response came from rosbridge with the given ID.
  */
-export default class Ros extends EventEmitter<
-  {
-    open: [TransportEvent];
-    close: [TransportEvent];
-    error: [TransportEvent];
-    // Any dynamically-named event should correspond to a rosbridge protocol message
-  } & Record<string, [RosbridgeMessage]>
-> {
+export default class Ros extends EventEmitter<RosEventTypes> {
   // private write, public read via getter method
   #isConnected: boolean;
 

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -724,7 +724,7 @@ export default class Ros extends EventEmitter<RosEventTypes> {
     );
   }
 
-  public Topic<T>(
+  public Topic<T extends object>(
     options: Omit<ConstructorParameters<typeof Topic<T>>[0], "ros">,
   ) {
     return new Topic<T>({ ros: this, ...options });
@@ -736,7 +736,7 @@ export default class Ros extends EventEmitter<RosEventTypes> {
     return new Param<T>({ ros: this, ...options });
   }
 
-  public Service<TRequest, TResponse>(
+  public Service<TRequest extends object, TResponse extends object>(
     options: Omit<
       ConstructorParameters<typeof Service<TRequest, TResponse>>[0],
       "ros"
@@ -751,7 +751,11 @@ export default class Ros extends EventEmitter<RosEventTypes> {
     return new TFClient({ ros: this, ...options });
   }
 
-  public ActionClient<TGoal, TFeedback, TResult>(
+  public ActionClient<
+    TGoal extends object,
+    TFeedback extends object,
+    TResult extends object,
+  >(
     options: Omit<
       ConstructorParameters<typeof ActionClient<TGoal, TFeedback, TResult>>[0],
       "ros"

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -3,19 +3,12 @@
  * @author Brandon Alexander - baalexander@gmail.com
  */
 
-import type {
-  RosbridgeMessage,
-  RosbridgeSetStatusLevelMessage,
-} from "../types/protocol.js";
 import {
-  isRosbridgeActionFeedbackMessage,
-  isRosbridgeActionResultMessage,
-  isRosbridgeCallServiceMessage,
-  isRosbridgeCancelActionGoalMessage,
-  isRosbridgePublishMessage,
-  isRosbridgeSendActionGoalMessage,
-  isRosbridgeServiceResponseMessage,
-  isRosbridgeStatusMessage,
+  type BridgeProtoOp,
+  isBridgeProtoOp,
+  type SetStatusLevelOp,
+  type BridgeStatusLevel,
+  type AuthOp,
 } from "../types/protocol.js";
 
 import Topic from "./Topic.js";
@@ -106,7 +99,7 @@ export default class Ros extends EventEmitter<RosEventTypes> {
       this.emit("error", event);
     });
 
-    transport.on("message", (message: RosbridgeMessage) => {
+    transport.on("message", (message: BridgeProtoOp) => {
       this.handleMessage(message);
     });
   }
@@ -115,26 +108,31 @@ export default class Ros extends EventEmitter<RosEventTypes> {
     this.transport?.close();
   }
 
-  private handleMessage(message: RosbridgeMessage) {
-    if (isRosbridgePublishMessage(message)) {
+  private handleMessage(message: unknown) {
+    if (!isBridgeProtoOp(message)) {
+      console.error("Received non-BridgeProtoOp message:", message);
+      return;
+    }
+
+    if (message.op === "publish") {
       this.emit(message.topic, message);
-    } else if (isRosbridgeServiceResponseMessage(message)) {
+    } else if (message.op === "service_response") {
       if (message.id) {
         this.emit(message.id, message);
       } else {
         console.error("Received service response without ID");
       }
-    } else if (isRosbridgeCallServiceMessage(message)) {
+    } else if (message.op === "call_service") {
       this.emit(message.service, message);
-    } else if (isRosbridgeSendActionGoalMessage(message)) {
+    } else if (message.op === "send_action_goal") {
       this.emit(message.action, message);
-    } else if (isRosbridgeCancelActionGoalMessage(message)) {
+    } else if (message.op === "cancel_action_goal") {
       this.emit(message.id, message);
-    } else if (isRosbridgeActionFeedbackMessage(message)) {
+    } else if (message.op === "action_feedback") {
       this.emit(message.id, message);
-    } else if (isRosbridgeActionResultMessage(message)) {
+    } else if (message.op === "action_result") {
       this.emit(message.id, message);
-    } else if (isRosbridgeStatusMessage(message)) {
+    } else if (message.op === "status") {
       if (message.id) {
         this.emit(`status:${message.id}`, message);
       } else {
@@ -159,12 +157,12 @@ export default class Ros extends EventEmitter<RosEventTypes> {
     client: string,
     dest: string,
     rand: string,
-    t: object,
+    t: number,
     level: string,
-    end: object,
+    end: number,
   ) {
     // create the request
-    const auth = {
+    const auth: AuthOp = {
       op: "auth",
       mac: mac,
       client: client,
@@ -182,10 +180,7 @@ export default class Ros extends EventEmitter<RosEventTypes> {
    * Sends the message to the transport.
    * If not connected, queues the message to send once reconnected.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- to broaden argument type to any RosbridgeMessage variant
-  public callOnConnection<T extends RosbridgeMessage = RosbridgeMessage>(
-    message: T,
-  ) {
+  public callOnConnection(message: BridgeProtoOp) {
     if (this.isConnected()) {
       this.transport?.send(message);
     } else {
@@ -201,8 +196,8 @@ export default class Ros extends EventEmitter<RosEventTypes> {
    * @param level - Status level (none, error, warning, info).
    * @param [id] - Operation ID to change status level on.
    */
-  public setStatusLevel(level: string, id?: string) {
-    const levelMsg: RosbridgeSetStatusLevelMessage = {
+  public setStatusLevel(level: BridgeStatusLevel, id?: string) {
+    const levelMsg: SetStatusLevelOp = {
       op: "set_level",
       level,
       id,

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -14,16 +14,22 @@ import {
 } from "../types/protocol.js";
 import type { ServiceCallIdString } from "../types/emitted_events.js";
 
+type ServiceMessageHandler<
+  TRequest extends object,
+  TResponse extends object,
+> = (request: AnyServiceOp<TRequest, TResponse>) => void;
 
 /**
  * A ROS service client.
  */
-export default class Service<TRequest, TResponse> extends EventEmitter {
+export default class Service<
+  TRequest extends object,
+  TResponse extends object,
+> extends EventEmitter {
   /**
    * Stores a reference to the most recent service callback advertised so it can be removed from the EventEmitter during un-advertisement
    */
-  #serviceCallback: ((rosbridgeRequest: RosbridgeMessage) => void) | null =
-    null;
+  #serviceCallback: ServiceMessageHandler<TRequest, TResponse> | null = null;
   isAdvertised = false;
   /**
    * Queue for serializing advertise/unadvertise operations to prevent race conditions

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -110,57 +110,20 @@ export default class Service<
 
     this.ros.callOnConnection(call);
   }
+
   /**
-   * Advertise the service. This turns the Service object from a client
-   * into a server. The callback will be called with every request
-   * that's made on this service.
-   *
-   * @param callback This works similarly to the callback for a C++ service in that you should take care not to overwrite the response object.
-   *  Instead, only modify the values within.
+   * Common logic for advertising a service
    */
-  async advertise(
-    callback: (request: TRequest, response: Partial<TResponse>) => boolean,
+  #advertiseWithCallback(
+    callbackWrapper: (bridgeMessage: AnyServiceOp<TRequest, TResponse>) => void,
   ): Promise<void> {
-    // Queue this operation to prevent race conditions
     this.#operationQueue = this.#operationQueue
       .then(() => {
-        // If already advertised, unadvertise first
         if (this.isAdvertised) {
           this.#doUnadvertise();
         }
 
-        // Store the new callback for removal during un-advertisement
-        this.#serviceCallback = (rosbridgeRequest) => {
-          if (!isRosbridgeCallServiceMessage<TRequest>(rosbridgeRequest)) {
-            throw new Error(
-              `Invalid message received on service channel: ${JSON.stringify(rosbridgeRequest)}`,
-            );
-          }
-          const response = {};
-          let success: boolean;
-          try {
-            success = callback(rosbridgeRequest.args, response);
-          } catch {
-            success = false;
-          }
-
-          if (success) {
-            this.ros.callOnConnection({
-              op: "service_response",
-              service: this.name,
-              values: response,
-              result: success,
-              id: rosbridgeRequest.id,
-            } satisfies RosbridgeServiceResponseMessage<Partial<TResponse>>);
-          } else {
-            this.ros.callOnConnection({
-              op: "service_response",
-              service: this.name,
-              result: success,
-              id: rosbridgeRequest.id,
-            } satisfies RosbridgeServiceResponseMessage<Partial<TResponse>>);
-          }
-        };
+        this.#serviceCallback = callbackWrapper;
 
         this.ros.on(this.name, this.#serviceCallback);
         this.ros.callOnConnection({
@@ -176,6 +139,53 @@ export default class Service<
       });
 
     return this.#operationQueue;
+  }
+
+  /**
+   * Advertise the service. This turns the Service object from a client
+   * into a server. The callback will be called with every request
+   * that's made on this service.
+   *
+   * @param callback This works similarly to the callback for a C++ service in that you should take care not to overwrite the response object.
+   *  Instead, only modify the values within.
+   */
+  advertise(
+    callback: (request: TRequest, response: Partial<TResponse>) => boolean,
+  ): Promise<void> {
+    return this.#advertiseWithCallback((bridgeMessage) => {
+      if (bridgeMessage.op !== "call_service") {
+        throw new Error(
+          `Invalid message received on service channel: ${JSON.stringify(bridgeMessage)}`,
+        );
+      }
+
+      const request = bridgeMessage as IncomingCallServiceOp<TRequest>;
+      const response: Partial<TResponse> = {};
+
+      let success: boolean;
+      try {
+        success = callback(request.args, response);
+      } catch {
+        success = false;
+      }
+
+      if (success) {
+        this.ros.callOnConnection({
+          op: "service_response",
+          service: this.name,
+          values: response,
+          result: success,
+          id: request.id,
+        });
+      } else {
+        this.ros.callOnConnection({
+          op: "service_response",
+          service: this.name,
+          result: success,
+          id: request.id,
+        });
+      }
+    });
   }
 
   /**
@@ -233,56 +243,37 @@ export default class Service<
    * An alternate form of Service advertisement that supports a modern Promise-based interface for use with async/await.
    * @param callback An asynchronous callback processing the request and returning a response.
    */
-  async advertiseAsync(
+  advertiseAsync(
     callback: (request: TRequest) => Promise<TResponse>,
   ): Promise<void> {
-    // Queue this operation to prevent race conditions
-    this.#operationQueue = this.#operationQueue
-      .then(() => {
-        // If already advertised, unadvertise first
-        if (this.isAdvertised) {
-          this.#doUnadvertise();
+    return this.#advertiseWithCallback((bridgeMessage) => {
+      if (bridgeMessage.op !== "call_service") {
+        throw new Error(
+          `Invalid message received on service channel: ${JSON.stringify(bridgeMessage)}`,
+        );
+      }
+
+      const request = bridgeMessage as IncomingCallServiceOp<TRequest>;
+
+      (async () => {
+        try {
+          this.ros.callOnConnection({
+            op: "service_response",
+            service: this.name,
+            result: true,
+            values: await callback(request.args),
+            id: request.id,
+          });
+        } catch (err) {
+          this.ros.callOnConnection({
+            op: "service_response",
+            service: this.name,
+            result: false,
+            values: String(err),
+            id: request.id,
+          });
         }
-
-        this.#serviceCallback = (rosbridgeRequest) => {
-          if (!isRosbridgeCallServiceMessage<TRequest>(rosbridgeRequest)) {
-            throw new Error(
-              `Invalid message received on service channel: ${JSON.stringify(rosbridgeRequest)}`,
-            );
-          }
-          (async () => {
-            try {
-              this.ros.callOnConnection({
-                op: "service_response",
-                service: this.name,
-                result: true,
-                values: await callback(rosbridgeRequest.args),
-                id: rosbridgeRequest.id,
-              } satisfies RosbridgeServiceResponseMessage<TResponse>);
-            } catch (err) {
-              this.ros.callOnConnection({
-                op: "service_response",
-                service: this.name,
-                result: false,
-                values: String(err),
-                id: rosbridgeRequest.id,
-              } satisfies RosbridgeServiceResponseMessage<TResponse>);
-            }
-          })().catch(console.error);
-        };
-        this.ros.on(this.name, this.#serviceCallback);
-        this.ros.callOnConnection({
-          op: "advertise_service",
-          type: this.serviceType,
-          service: this.name,
-        });
-        this.isAdvertised = true;
-      })
-      .catch((err: unknown) => {
-        this.emit("error", err);
-        throw err;
-      });
-
-    return this.#operationQueue;
+      })().catch(console.error);
+    });
   }
 }

--- a/src/core/Service.ts
+++ b/src/core/Service.ts
@@ -4,16 +4,16 @@
  */
 
 import { EventEmitter } from "eventemitter3";
-import type {
-  RosbridgeMessage,
-  RosbridgeServiceResponseMessage,
-} from "../types/protocol.ts";
-import {
-  isRosbridgeCallServiceMessage,
-  isRosbridgeServiceResponseMessage,
-} from "../types/protocol.ts";
 import type Ros from "./Ros.js";
 import { v4 as uuidv4 } from "uuid";
+import {
+  type AnyServiceOp,
+  isServiceResponseSuccess,
+  type CallServiceOp,
+  type IncomingCallServiceOp,
+} from "../types/protocol.js";
+import type { ServiceCallIdString } from "../types/emitted_events.js";
+
 
 /**
  * A ROS service client.
@@ -76,23 +76,28 @@ export default class Service<TRequest, TResponse> extends EventEmitter {
       return;
     }
 
-    const serviceCallId = `call_service:${this.name}:${uuidv4()}`;
+    const serviceCallId: ServiceCallIdString = `call_service:${this.name}:${uuidv4()}`;
 
-    this.ros.once(serviceCallId, function (message) {
-      if (isRosbridgeServiceResponseMessage<TResponse>(message)) {
-        if (!message.result) {
-          failedCallback(message.values ?? "");
-        } else {
-          callback?.(message.values);
+    this.ros.once(
+      serviceCallId,
+      (message: AnyServiceOp<TRequest, TResponse>) => {
+        if (message.op !== "service_response") {
+          return;
         }
-      }
-    });
 
-    const call = {
+        if (isServiceResponseSuccess<TResponse>(message)) {
+          callback?.(message.values);
+          return;
+        }
+
+        failedCallback(message.values ?? "");
+      },
+    );
+
+    const call: CallServiceOp<TRequest> = {
       op: "call_service",
       id: serviceCallId,
       service: this.name,
-      type: this.serviceType,
       args: request,
       timeout: timeout,
     };

--- a/src/core/Topic.ts
+++ b/src/core/Topic.ts
@@ -17,6 +17,17 @@ import {
   type PublishOp,
 } from "../types/protocol.js";
 
+interface TopicOptions {
+  ros: Ros;
+  name: string;
+  messageType: string;
+  compression?: BridgeCompressionType;
+  throttle_rate?: number;
+  queue_size?: number;
+  latch?: boolean;
+  queue_length?: number;
+  reconnect_on_close?: boolean;
+}
 
 /**
  * Publish and/or subscribe to a topic in ROS.
@@ -25,7 +36,7 @@ import {
  *  * 'warning' - If there are any warning during the Topic creation.
  *  * 'message' - The message data from rosbridge.
  */
-export default class Topic<T> extends EventEmitter<{
+export default class Topic<T extends object> extends EventEmitter<{
   message: [T];
   warning: [string];
   unsubscribe: undefined;
@@ -43,9 +54,7 @@ export default class Topic<T> extends EventEmitter<{
   queue_size: number;
   queue_length: number;
   reconnect_on_close: boolean;
-  callForSubscribeAndAdvertise: (
-    message: RosbridgeSubscribeMessage | RosbridgeAdvertiseMessage,
-  ) => void;
+  callForSubscribeAndAdvertise: (message: SubscribeOp | AdvertiseOp) => void;
   subscribeId: string | null = null;
   advertiseId?: string;
   /**
@@ -70,17 +79,7 @@ export default class Topic<T> extends EventEmitter<{
     queue_size = 100,
     queue_length = 0,
     reconnect_on_close = true,
-  }: {
-    ros: Ros;
-    name: string;
-    messageType: string;
-    compression?: string;
-    throttle_rate?: number;
-    queue_size?: number;
-    latch?: boolean;
-    queue_length?: number;
-    reconnect_on_close?: boolean;
-  }) {
+  }: TopicOptions) {
     super();
 
     this.ros = ros;

--- a/src/core/Topic.ts
+++ b/src/core/Topic.ts
@@ -6,14 +6,17 @@
 import { EventEmitter } from "eventemitter3";
 import Service from "./Service.js";
 import type Ros from "./Ros.js";
-import {
-  isRosbridgePublishMessage,
-  type RosbridgeAdvertiseMessage,
-  type RosbridgeMessage,
-  type RosbridgeSubscribeMessage,
-} from "../types/protocol.ts";
 import type { rosapi } from "../types/rosapi.ts";
 import { v4 as uuidv4 } from "uuid";
+import {
+  type BridgeCompressionType,
+  type SubscribeOp,
+  type AdvertiseOp,
+  type BridgeProtoOp,
+  isValidBridgeCompression,
+  type PublishOp,
+} from "../types/protocol.js";
+
 
 /**
  * Publish and/or subscribe to a topic in ROS.
@@ -34,7 +37,7 @@ export default class Topic<T> extends EventEmitter<{
   ros: Ros;
   name: string;
   messageType: string;
-  compression: string;
+  compression: BridgeCompressionType;
   throttle_rate: number;
   latch: boolean;
   queue_size: number;
@@ -91,18 +94,10 @@ export default class Topic<T> extends EventEmitter<{
     this.reconnect_on_close = reconnect_on_close;
 
     // Check for valid compression types
-    if (
-      this.compression &&
-      this.compression !== "png" &&
-      this.compression !== "cbor" &&
-      this.compression !== "cbor-raw" &&
-      this.compression !== "none"
-    ) {
+    if (!isValidBridgeCompression(this.compression)) {
       this.emit(
         "warning",
-        `${
-          this.compression
-        } compression is not supported. No compression will be used.`,
+        `${compression} compression is not supported. No compression will be used.`,
       );
       this.compression = "none";
     }
@@ -139,14 +134,13 @@ export default class Topic<T> extends EventEmitter<{
     }
   }
 
-  #messageCallback = (data: RosbridgeMessage) => {
-    if (isRosbridgePublishMessage<T>(data)) {
-      this.emit("message", data.msg);
-    } else {
+  #messageCallback = (data: BridgeProtoOp<T>) => {
+    if (data.op !== "publish") {
       throw new Error(
         `Unexpected message on topic channel: ${JSON.stringify(data)}`,
       );
     }
+    this.emit("message", data.msg);
   };
   /**
    * Every time a message is published for the given topic, the callback
@@ -258,7 +252,7 @@ export default class Topic<T> extends EventEmitter<{
       this.advertise();
     }
 
-    const call = {
+    const call: PublishOp<T> = {
       op: "publish",
       id: `publish:${this.name}:${uuidv4()}`,
       topic: this.name,

--- a/src/core/transport/NativeWebSocketTransport.ts
+++ b/src/core/transport/NativeWebSocketTransport.ts
@@ -1,5 +1,5 @@
-import type { RosbridgeMessage } from "../../types/protocol.js";
 import { AbstractTransport } from "./Transport.js";
+import type { BridgeProtoOp } from "../../types/protocol.js";
 
 /**
  * Uses the native `WebSocket` class to send and receive messages.
@@ -15,7 +15,7 @@ export class NativeWebSocketTransport extends AbstractTransport {
     this.registerEventListeners();
   }
 
-  public send(message: RosbridgeMessage): void {
+  public send(message: BridgeProtoOp): void {
     this.socket.send(JSON.stringify(message));
   }
 

--- a/src/core/transport/Transport.ts
+++ b/src/core/transport/Transport.ts
@@ -1,18 +1,14 @@
 import EventEmitter from "eventemitter3";
-import type {
-  RosbridgePngMessage,
-  RosbridgeMessage,
-  RosbridgeFragmentMessage,
-} from "../../types/protocol.js";
-import {
-  isRosbridgeFragmentMessage,
-  isRosbridgeMessage,
-  isRosbridgePngMessage,
-} from "../../types/protocol.js";
 import { deserialize } from "bson";
 import CBOR from "cbor-js";
 import typedArrayTagger from "../../util/cborTypedArrayTags.js";
 import decompressPng from "../../util/decompressPng.js";
+import {
+  type BridgeProtoOp,
+  type FragmentOp,
+  isBridgeProtoOp,
+  type PngOp,
+} from "../../types/protocol.js";
 
 /**
  * Because transport implementations may have different event types
@@ -33,9 +29,9 @@ export interface ITransport {
     listener: (event: TransportEvent) => void,
   ): this;
 
-  on(event: "message", listener: (message: RosbridgeMessage) => void): this;
+  on(event: "message", listener: (message: BridgeProtoOp) => void): this;
 
-  send(message: RosbridgeMessage): void;
+  send(message: BridgeProtoOp): void;
 
   close(): void;
 
@@ -60,7 +56,7 @@ export abstract class AbstractTransport
     open: [TransportEvent];
     close: [TransportEvent];
     error: [TransportEvent];
-    message: [RosbridgeMessage];
+    message: [BridgeProtoOp];
   }>
   implements ITransport
 {
@@ -68,7 +64,7 @@ export abstract class AbstractTransport
    * Buffer Map for incoming message fragments.
    */
   #fragmentBuffer = new Map<
-    RosbridgeFragmentMessage["id"],
+    FragmentOp["id"],
     {
       fragments: string[];
       received: number;
@@ -76,7 +72,7 @@ export abstract class AbstractTransport
     }
   >();
 
-  abstract send(message: RosbridgeMessage): void;
+  abstract send(message: BridgeProtoOp): void;
   abstract close(): void;
   abstract isConnecting(): boolean;
   abstract isOpen(): boolean;
@@ -94,7 +90,7 @@ export abstract class AbstractTransport
    */
   protected handleRawMessage(data: unknown): void {
     try {
-      if (isRosbridgeMessage(data)) {
+      if (isBridgeProtoOp(data)) {
         this.handleRosbridgeMessage(data);
       } else if (typeof Blob !== "undefined" && data instanceof Blob) {
         this.handleBsonMessage(data);
@@ -114,10 +110,10 @@ export abstract class AbstractTransport
    * If the message is a PNG, it is decompressed and reprocessed.
    * Otherwise, the message is emitted.
    */
-  private handleRosbridgeMessage(message: RosbridgeMessage) {
-    if (isRosbridgeFragmentMessage(message)) {
+  private handleRosbridgeMessage(message: BridgeProtoOp) {
+    if (message.op === "fragment") {
       this.handleRosbridgeFragmentMessage(message);
-    } else if (isRosbridgePngMessage(message)) {
+    } else if (message.op === "png") {
       this.handleRosbridgePngMessage(message);
     } else {
       this.emit("message", message);
@@ -128,7 +124,7 @@ export abstract class AbstractTransport
    * Appends a fragment to the current fragment buffer for the message id.
    * If all fragments are received, the message is reconstructed and processed.
    */
-  private handleRosbridgeFragmentMessage(fragment: RosbridgeFragmentMessage) {
+  private handleRosbridgeFragmentMessage(fragment: FragmentOp) {
     const { id, data, num, total } = fragment;
     if (
       !id ||
@@ -174,7 +170,7 @@ export abstract class AbstractTransport
       } finally {
         this.#fragmentBuffer.delete(id);
       }
-      if (isRosbridgeMessage(message)) {
+      if (isBridgeProtoOp(message)) {
         this.handleRosbridgeMessage(message);
       } else {
         throw new Error("Received invalid rosbridge message!");
@@ -186,9 +182,9 @@ export abstract class AbstractTransport
    * Decompresses a PNG image expecting the result to be a RosbridgeMessage.
    * It is one technique for compressing JSON data.
    */
-  private handleRosbridgePngMessage(message: RosbridgePngMessage) {
+  private handleRosbridgePngMessage(message: PngOp) {
     const decoded = decompressPng(message.data);
-    if (isRosbridgeMessage(decoded)) {
+    if (isBridgeProtoOp(decoded)) {
       this.handleRosbridgeMessage(decoded);
     } else {
       throw new Error("Decompressed PNG data was invalid!");
@@ -205,7 +201,7 @@ export abstract class AbstractTransport
       if (reader.result instanceof ArrayBuffer) {
         const uint8Array = new Uint8Array(reader.result);
         const data: unknown = deserialize(uint8Array);
-        if (isRosbridgeMessage(data)) {
+        if (isBridgeProtoOp(data)) {
           this.handleRosbridgeMessage(data);
         } else {
           this.emit("error", new Error("Decoded BSON data was invalid!"));
@@ -221,7 +217,7 @@ export abstract class AbstractTransport
    */
   private handleCborMessage(cbor: ArrayBuffer) {
     const data: unknown = CBOR.decode(cbor, typedArrayTagger);
-    if (isRosbridgeMessage(data)) {
+    if (isBridgeProtoOp(data)) {
       this.handleRosbridgeMessage(data);
     } else {
       throw new Error("Decoded CBOR data was invalid!");
@@ -233,7 +229,7 @@ export abstract class AbstractTransport
    */
   private handleJsonMessage(json: string) {
     const message: unknown = JSON.parse(json);
-    if (isRosbridgeMessage(message)) {
+    if (isBridgeProtoOp(message)) {
       this.handleRosbridgeMessage(message);
     } else {
       throw new Error("Received invalid rosbridge message!");

--- a/src/core/transport/WsWebSocketTransport.ts
+++ b/src/core/transport/WsWebSocketTransport.ts
@@ -1,5 +1,5 @@
 import * as ws from "ws";
-import type { RosbridgeMessage } from "../../types/protocol.js";
+import type { BridgeProtoOp } from "../../types/protocol.js";
 import { AbstractTransport } from "./Transport.js";
 
 /**
@@ -16,7 +16,7 @@ export class WsWebSocketTransport extends AbstractTransport {
     this.registerEventListeners();
   }
 
-  public send(message: RosbridgeMessage): void {
+  public send(message: BridgeProtoOp): void {
     this.socket.send(JSON.stringify(message));
   }
 

--- a/src/tf/TFClient.ts
+++ b/src/tf/TFClient.ts
@@ -16,13 +16,11 @@ import BaseTFClient from "./BaseTFClient.js";
  * A TF Client that listens to TFs from tf2_web_republisher.
  */
 export default class TFClient extends BaseTFClient {
-  currentGoal:
-    | Goal<
-        tf2_web_republisher.TFSubscriptionGoal,
-        tf2_web_republisher.TFSubscriptionFeedback
-      >
-    | false = false;
-  currentTopic: Topic<tf2_msgs.TFMessage> | false = false;
+  currentGoal?: Goal<
+    tf2_web_republisher.TFSubscriptionGoal,
+    tf2_web_republisher.TFSubscriptionFeedback
+  >;
+  currentTopic?: Topic<tf2_msgs.TFMessage>;
   actionClient: ActionClient<
     tf2_web_republisher.TFSubscriptionGoal,
     tf2_web_republisher.TFSubscriptionFeedback

--- a/src/types/emitted_events.ts
+++ b/src/types/emitted_events.ts
@@ -1,0 +1,38 @@
+import type { TransportEvent } from "../core/transport/Transport.js";
+import type {
+  BridgeProtoOpKey,
+  AnyActionOp,
+  AnyServiceOp,
+} from "./protocol.js";
+
+export type TransportEventString = "open" | "close" | "error";
+export type TransportEvents = Record<
+  TransportEventString,
+  [event: TransportEvent]
+>;
+
+export type ActionIdString = `send_action_goal:${string}:${string}`;
+export type ServiceCallIdString = `call_service:${string}:${string}`;
+export type TopicKey = Exclude<
+  string,
+  TransportEventString | ActionIdString | ServiceCallIdString | BridgeProtoOpKey
+>;
+
+// Event strings specific to actions
+export type RosActionEvents = Record<
+  ActionIdString,
+  // Allow the action class to narrow the type itself.
+  [message: AnyActionOp<never, never, never>]
+>;
+
+export type RosServiceEvents = Record<
+  ServiceCallIdString,
+  // Allow the action class to narrow the type itself.
+  [message: AnyServiceOp<never, never>]
+>;
+
+export type RosEventTypes = TransportEvents &
+  RosActionEvents & // Action Events
+  RosServiceEvents &
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Record<TopicKey, [message: any]>; // Service Calls & Topic messages, need to be `any` to be coerced by implementers

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,323 +1,574 @@
-/**
- * https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/ROSBRIDGE_PROTOCOL.md
- */
+// Base interface for common fields across all operations
 
-export interface RosbridgeMessage {
-  op: string;
+import { hasOwn } from "../util/type-utils.ts";
+import type { GoalStatus } from "../core/GoalStatus.ts";
+
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
+export type BridgeStatusLevel = "info" | "warning" | "error" | "none";
+export type BridgeCompressionType = "none" | "png" | "cbor" | "cbor-raw";
+
+export function isValidBridgeCompression(
+  compression: string,
+): compression is BridgeCompressionType {
+  return ["none", "png", "cbor", "cbor-raw"].includes(compression);
 }
 
-export function isRosbridgeMessage(
-  message: unknown,
-): message is RosbridgeMessage {
-  return (
-    message instanceof Object &&
-    "op" in message &&
-    typeof message.op === "string"
-  );
-}
-
-export interface RosbridgeStatusMessage extends RosbridgeMessage {
-  op: "status";
+export interface BaseOp<T extends string> {
+  op: T;
   id?: string;
-  level: string;
-  msg: string;
 }
 
-export function isRosbridgeStatusMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeStatusMessage {
-  return message.op === "status";
-}
-
-export interface RosbridgeSetStatusLevelMessage extends RosbridgeMessage {
-  op: "set_level";
-  id?: string;
-  level: string;
-}
-
-export function isRosbridgeSetStatusLevelMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeSetStatusLevelMessage {
-  return message.op === "set_level";
-}
-
-export interface RosbridgeFragmentMessage extends RosbridgeMessage {
-  op: "fragment";
-  id: string;
-  data: string;
-  num: number;
-  total: number;
-}
-
-export function isRosbridgeFragmentMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeFragmentMessage {
-  return message.op === "fragment";
-}
-
-export interface RosbridgePngMessage extends RosbridgeMessage {
-  op: "png";
-  id?: string;
-  data: string;
-  num?: number;
-  total?: number;
-}
-
-export function isRosbridgePngMessage(
-  message: RosbridgeMessage,
-): message is RosbridgePngMessage {
-  return message.op === "png";
-}
-
-export interface RosbridgeAdvertiseMessage extends RosbridgeMessage {
-  op: "advertise";
-  id?: string;
-  type: string;
-  topic: string;
+export interface QoSOp<T extends string> extends BaseOp<T> {
+  /**
+   * ROS1: Passed to publisher
+   * ROS2: Sets QoS to infinite lifespan and depth of 1
+   */
   latch?: boolean;
+  /**
+   * ROS1: Passed to publisher
+   * ROS2: Sets the QoS Queue Depth
+   */
   queue_size?: number;
 }
 
-export function isRosbridgeAdvertiseMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeAdvertiseMessage {
-  return message.op === "advertise";
+export interface AuthOp extends BaseOp<"auth"> {
+  mac: string;
+  client: string;
+  dest: string;
+  rand: string;
+  t: number;
+  level: string;
+  end: number;
 }
 
-export interface RosbridgeUnadvertiseMessage extends RosbridgeMessage {
-  op: "unadvertise";
+//region Data transformation operations
+export interface FragmentOp extends BaseOp<"fragment"> {
+  /**
+   * An id is required for fragmented messages, to identify corresponding fragments for the fragmented message.
+   */
+  id: string;
+  /**
+   * A fragment of data that, when combined with other fragments of data, makes up another message
+   */
+  data: string;
+  /**
+   * The index of the fragment in the message
+   */
+  num: number;
+  /**
+   * The total number of fragments
+   */
+  total: number;
+}
+
+export interface PngOp extends BaseOp<"png"> {
+  /**
+   * Only required if the message is fragmented. Identifies the fragments for the fragmented message.
+   */
   id?: string;
-  topic: string;
+  /**
+   * A fragment of a PNG-encoded message or an entire message.
+   */
+  data: string;
+  /**
+   * Only required if the message is fragmented. The index of the fragment.
+   */
+  num?: number;
+  /**
+   * Only required if the message is fragmented. The total number of fragments.
+   */
+  total?: number;
 }
 
-export function isRosbridgeUnadvertiseMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeUnadvertiseMessage {
-  return message.op === "unadvertise";
+//endregion
+
+//region Status operations
+export interface SetStatusLevelOp extends BaseOp<"set_level"> {
+  level: BridgeStatusLevel;
 }
 
-export interface RosbridgePublishMessage<TMessage = unknown>
-  extends RosbridgeMessage {
-  op: "publish";
+export interface StatusOp extends BaseOp<"status"> {
+  /**
+   * If the status message was the result of some operation that had an id, then that id is included
+   */
   id?: string;
+  /**
+   * The level of this status message
+   */
+  level: BridgeStatusLevel;
+  /**
+   * The string message being logged
+   */
+  msg: string;
+}
+
+//endregion
+
+//region Topic operations
+
+/**
+ *
+ * If the topic does not already exist, and the type specified is a valid type, then the topic will be established with this type.
+ *
+ * If the topic already exists with a different type, an error status message is sent and this message is dropped.
+ *
+ * If the topic already exists with the same type, the sender of this message is registered as another publisher.
+ *
+ * If the topic doesn't already exist but the type cannot be resolved, then an error status message is sent and this message is dropped.
+ */
+export interface AdvertiseOp extends QoSOp<"advertise"> {
+  /**
+   * The string name of the topic to advertise
+   */
   topic: string;
-  msg: TMessage;
-}
-
-export function isRosbridgePublishMessage<T>(
-  message: RosbridgeMessage,
-): message is RosbridgePublishMessage<T> {
-  return message.op === "publish";
-}
-
-export interface RosbridgeSubscribeMessage extends RosbridgeMessage {
-  op: "subscribe";
-  id?: string;
-  topic: string;
-  type?: string;
-  throttle_rate?: number;
-  queue_length?: number;
-  fragment_size?: number;
-  compression?: string;
-}
-
-export function isRosbridgeSubscribeMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeSubscribeMessage {
-  return message.op === "subscribe";
-}
-
-export interface RosbridgeUnsubscribeMessage extends RosbridgeMessage {
-  op: "unsubscribe";
-  id?: string;
-  topic: string;
-}
-
-export function isRosbridgeUnsubscribeMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeUnsubscribeMessage {
-  return message.op === "unsubscribe";
-}
-
-export interface RosbridgeAdvertiseServiceMessage extends RosbridgeMessage {
-  op: "advertise_service";
+  /**
+   * The string type to advertise for the topic
+   */
   type: string;
-  service: string;
 }
 
-export function isRosbridgeAdvertiseServiceMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeAdvertiseServiceMessage {
-  return message.op === "advertise_service";
+/**
+ * If the topic does not exist, a warning status message is sent and this message is dropped
+ *
+ * If the topic exists and there are still clients left advertising it, rosbridge will continue to advertise it until all of them have unadvertised
+ *
+ * If the topic exists but rosbridge is not advertising it, a warning status message is sent and this message is dropped
+ */
+export interface UnadvertiseOp extends BaseOp<"unadvertise"> {
+  /**
+   * The string name of the topic being unadvertised
+   */
+  topic: string;
 }
 
-export interface RosbridgeUnadvertiseServiceMessage extends RosbridgeMessage {
-  op: "unadvertise_service";
-  service: string;
+/**
+ * The publish command publishes a message on a topic.
+ *
+ * If the topic does not exist, then an error status message is sent and this message is dropped
+ *
+ * If the msg does not conform to the type of the topic, then an error status message is sent and this message is dropped
+ *
+ * If the msg is a subset of the type of the topic, then a warning status message is sent and the unspecified fields are filled in with defaults
+ *
+ * Special case: if the type being published has a 'header' field, then the client can optionally omit the header from the msg.
+ * If this happens, rosbridge will automatically populate the header with a frame id of "" and the timestamp as the current time.
+ * Alternatively, just the timestamp field can be omitted, and then the current time will be automatically inserted.
+ */
+export interface PublishOp<T extends object> extends QoSOp<"publish"> {
+  topic: string;
+  msg: T;
 }
 
-export function isRosbridgeUnadvertiseServiceMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeUnadvertiseServiceMessage {
-  return message.op === "unadvertise_service";
-}
-
-export interface RosbridgeCallServiceMessage<TArgs = undefined>
-  extends RosbridgeMessage {
-  op: "call_service";
+/**
+ * This command subscribes the client to the specified topic.
+ * It is recommended that if the client has multiple components subscribing to the same topic, that each component
+ * makes its own subscription request providing an ID. That way, each can individually unsubscribe and rosbridge can select the correct rate at which to send messages.
+ *
+ * If queue_length is specified, then messages are placed into the queue before being sent.
+ * Messages are sent from the head of the queue. If the queue gets full, the oldest message is removed and
+ * replaced by the newest message.
+ *
+ * If a client has multiple subscriptions to the same topic, then messages are sent at the lowest throttle_rate,
+ * with the lowest fragmentation size, and highest queue_length.
+ * It is recommended that the client provides IDs for its subscriptions to enable rosbridge to effectively
+ * choose the appropriate fragmentation size and publishing rate.
+ */
+export interface SubscribeOp extends BaseOp<"subscribe"> {
+  /**
+   * If specified, then this specific subscription can be unsubscribed by referencing the ID.
+   */
   id?: string;
+  /**
+   * The (expected) type of the topic to subscribe to.
+   * If left off, type will be inferred, and if the topic doesn't exist then the command to subscribe will fail
+   */
+  topic: string;
+  /**
+   * The name of the topic to subscribe to
+   */
+  type: string;
+  /**
+   * The minimum amount of time (in ms) that must elapse between messages being sent. Defaults to 0
+   */
+  throttle_rate?: number;
+  /**
+   * the size of the queue to buffer messages. Messages are buffered as a result of the throttle_rate. Defaults to 0 (no queueing).
+   */
+  queue_length?: number;
+  /**
+   * The maximum size that a message can take before it is to be fragmented.
+   */
+  fragment_size?: number;
+  /**
+   * An optional string to specify the compression scheme to be used on messages.
+   * Valid values are "none", "png", "cbor", and "cbor-raw".
+   */
+  compression?: BridgeCompressionType;
+}
+
+export interface UnsubscribeOp extends BaseOp<"unsubscribe"> {
+  /**
+   * An id of the subscription to unsubscribe.
+   * If an id is provided, then only the corresponding subscription is unsubscribed.
+   * If no ID is provided, then all subscriptions are unsubscribed.
+   */
+  id?: string;
+  /**
+   * The name of the topic to unsubscribe from
+   */
+  topic: string;
+}
+
+//endregion
+
+//region Service operations
+
+/**
+ * Advertises an external ROS service server. Requests come to the client via Call Service.
+ */
+export interface AdvertiseServiceOp extends BaseOp<"advertise_service"> {
+  /**
+   * The name of the service to advertise
+   */
   service: string;
   /**
-   * @todo this should be deeply partial when *outgoing*, because rosbridge will "fill in the blanks",
-   * but it's not partial when *incoming* - need to figure out a way to represent this.
+   * The advertised service message type
    */
-  args: TArgs;
+  type: string;
+}
+
+/**
+ * Stops advertising an external ROS service server
+ */
+export interface UnadvertiseServiceOp extends BaseOp<"unadvertise_service"> {
+  /**
+   * The name of the service to unadvertise
+   */
+  service: string;
+}
+
+/**
+ * Calls a ROS service.
+ */
+export interface CallServiceOp<TRequest extends object>
+  extends BaseOp<"call_service"> {
+  /**
+   * An optional id to distinguish this service call
+   */
+  id?: string;
+  /**
+   * The name of the service to call
+   */
+  service: string;
+  /**
+   * if the service has no args, then args does not have to be provided, though an empty list is equally acceptable.
+   * Args should be a list of json objects representing the arguments to the service.
+   *
+   * If outgoing, the message can be partial; Rosbridge will "fill in the blanks".
+   * If incoming, the message will be complete
+   *
+   * @see IncomingCallServiceOp
+   */
+  args: TRequest | DeepPartial<TRequest>;
+  /**
+   * The maximum size that the response message can take before it is fragmented
+   */
   fragment_size?: number;
-  compression?: string;
+  /**
+   * An optional string to specify the compression scheme to be used on messages. Valid values are "none" and "png"
+   */
+  compression?: Extract<BridgeCompressionType, "none" | "png">;
+  /**
+   * The time, in seconds, to wait for a response from the server
+   */
   timeout?: number;
 }
 
-export function isRosbridgeCallServiceMessage<T>(
-  message: RosbridgeMessage,
-): message is RosbridgeCallServiceMessage<T> {
-  return message.op === "call_service";
-}
+/**
+ * Operation sent by the Bridge to RosLibJS to call a locally advertised service.
+ */
+export type IncomingCallServiceOp<TRequest extends object> = Omit<
+  CallServiceOp<TRequest>,
+  "args"
+> & {
+  /**
+   * Incoming message args will be "filled in" by Rosbridge.
+   */
+  args: TRequest;
+};
 
-interface BaseRosbridgeServiceResponseMessage extends RosbridgeMessage {
-  op: "service_response";
+export interface ServiceResponseOp<TResponse extends object>
+  extends BaseOp<"service_response"> {
+  /**
+   * If an ID was provided to the service request, then the service response will contain the ID
+   */
   id?: string;
+  /**
+   * The name of the service that was called
+   */
   service: string;
+  /**
+   * The return values. If the service had no return values, then this field can be
+   * omitted (and will be by the rosbridge server)
+   */
+  values?: TResponse | string;
+  /**
+   * Return value of service callback. true means success, false failure.
+   */
   result: boolean;
 }
 
-/** If the service call failed, `values` will be a string error message. */
-interface FailedRosbridgeServiceResponseMessage
-  extends BaseRosbridgeServiceResponseMessage {
-  values?: string;
-  result: false;
-}
-
-interface SuccessfulRosbridgeServiceResponseMessage<TValues = undefined>
-  extends BaseRosbridgeServiceResponseMessage {
-  values: TValues;
+export interface ServiceResponseSuccessOp<TResponse extends object>
+  extends ServiceResponseOp<TResponse> {
+  /**
+   * The return values. If the service had no return values, then this field can be
+   * omitted (and will be by the rosbridge server)
+   */
+  values: TResponse;
+  /**
+   * Return value of service callback. true means success, false failure.
+   */
   result: true;
 }
 
-export type RosbridgeServiceResponseMessage<TValues = undefined> =
-  | FailedRosbridgeServiceResponseMessage
-  | SuccessfulRosbridgeServiceResponseMessage<TValues>;
-
-export function isRosbridgeServiceResponseMessage<T>(
-  message: RosbridgeMessage,
-): message is RosbridgeServiceResponseMessage<T> {
-  return message.op === "service_response";
+export interface ServiceResponseFailedOp extends ServiceResponseOp<never> {
+  /**
+   * The return values. If the service had no return values, then this field can be
+   * omitted (and will be by the rosbridge server)
+   */
+  values?: string;
+  /**
+   * Return value of service callback. true means success, false failure.
+   */
+  result: false;
 }
 
-export interface RosbridgeAdvertiseActionMessage extends RosbridgeMessage {
-  op: "advertise_action";
+export type AnyServiceResponseOp<TResponse extends object> =
+  | ServiceResponseSuccessOp<TResponse>
+  | ServiceResponseFailedOp;
+
+export type AnyServiceOp<
+  TRequest extends object = object,
+  TResponse extends object = object,
+> =
+  | AdvertiseServiceOp
+  | UnadvertiseServiceOp
+  | CallServiceOp<TRequest>
+  | IncomingCallServiceOp<TRequest>
+  | AnyServiceResponseOp<TResponse>;
+
+export function isServiceResponseSuccess<T extends object = object>(
+  obj: unknown,
+): obj is ServiceResponseSuccessOp<T> {
+  return (
+    isBridgeProtoOp(obj) &&
+    obj.op === "service_response" &&
+    hasOwn(obj, "result") &&
+    obj.result
+  );
+}
+
+//endregion
+
+//region Action operations
+
+/**
+ * Advertises an external ROS action server.
+ */
+export interface AdvertiseActionOp extends BaseOp<"advertise_action"> {
+  /**
+   * The name of the action to advertise
+   */
+  action: string;
+  /**
+   * The advertised action message type
+   */
   type: string;
+}
+
+/**
+ * Unadvertises an external ROS action server.
+ */
+export interface UnadvertiseActionOp extends BaseOp<"unadvertise_action"> {
+  /**
+   * The name of the action to unadvertise
+   */
   action: string;
 }
 
-export function isRosbridgeAdvertiseActionMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeAdvertiseActionMessage {
-  return message.op === "advertise_action";
-}
-
-export interface RosbridgeUnadvertiseActionMessage extends RosbridgeMessage {
-  op: "unadvertise_action";
+/**
+ * Sends a goal to a ROS action server.
+ */
+export interface SendActionGoalOp<TGoal extends object>
+  extends BaseOp<"send_action_goal"> {
+  /**
+   * An optional id to distinguish this goal handle
+   */
+  id?: string;
+  /**
+   * The name of the action to send a goal to
+   */
   action: string;
-}
-
-export function isRosbridgeUnadvertiseActionMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeUnadvertiseActionMessage {
-  return message.op === "unadvertise_action";
-}
-
-export interface RosbridgeSendActionGoalMessage<TArgs = unknown>
-  extends RosbridgeMessage {
-  op: "send_action_goal";
-  id: string;
-  action: string;
+  /**
+   * The action message type
+   */
   action_type: string;
-  args?: TArgs;
+  /**
+   * If the goal has no args, then args does not have to be provided, though an empty list is equally acceptable.
+   * Args should be a list of json objects representing the arguments to the service.
+   */
+  args?: TGoal;
+  /**
+   * If true, sends feedback messages over rosbridge. Defaults to false.
+   */
   feedback?: boolean;
+  /**
+   * The maximum size that the result and feedback messages can take before they are fragmented
+   */
   fragment_size?: number;
-  compression?: string;
+  /**
+   * An optional string to specify the compression scheme to be used on messages. Valid values are "none" and "png"
+   */
+  compression?: Extract<BridgeCompressionType, "none" | "png">;
 }
 
-export function isRosbridgeSendActionGoalMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeSendActionGoalMessage {
-  return message.op === "send_action_goal";
-}
-
-export interface RosbridgeCancelActionGoalMessage extends RosbridgeMessage {
-  op: "cancel_action_goal";
+export interface CancelActionGoalOp extends BaseOp<"cancel_action_goal"> {
+  /**
+   * The id representing the goal handle to cancel.
+   * The id field must match an already in-progress goal.
+   */
   id: string;
+  /**
+   * The name of the action to cancel
+   */
   action: string;
 }
 
-export function isRosbridgeCancelActionGoalMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeCancelActionGoalMessage {
-  return message.op === "cancel_action_goal";
-}
-
-export interface RosbridgeActionFeedbackMessage<TFeedback = unknown>
-  extends RosbridgeMessage {
-  op: "action_feedback";
+/**
+ * Used to send action feedback for a specific goal handle.
+ */
+export interface ActionFeedbackOp<TFeedback extends object>
+  extends BaseOp<"action_feedback"> {
+  /**
+   * The id representing the goal handle.
+   * The id field must match an already in-progress goal.
+   */
   id: string;
+  /**
+   * The name of the action to cancel
+   */
   action: string;
+  /**
+   * The feedback values
+   */
   values: TFeedback;
 }
 
-export function isRosbridgeActionFeedbackMessage<TFeedback = unknown>(
-  message: RosbridgeMessage,
-): message is RosbridgeActionFeedbackMessage<TFeedback> {
-  return message.op === "action_feedback";
-}
-
-interface RosbridgeActionResultMessageBase extends RosbridgeMessage {
-  op: "action_result";
+/**
+ * A result for a ROS action.
+ */
+export interface ActionResultSuccessOp<TResult extends object>
+  extends BaseOp<"action_result"> {
+  /**
+   * If an ID was provided to the action goal, then the action result will contain the ID
+   */
   id: string;
+  /**
+   * The name of the action that was executed
+   */
   action: string;
-  status: number;
-}
-
-interface FailedRosbridgeActionResultMessage
-  extends RosbridgeActionResultMessageBase {
-  result: false;
-  values?: string;
-}
-
-interface SuccessfulRosbridgeActionResultMessage<TResultValues = unknown>
-  extends RosbridgeActionResultMessageBase {
-  values: TResultValues;
+  /**
+   * The result values. If the service had no return values, then this field can be omitted (and will be by the rosbridge server)
+   */
+  values: TResult;
+  /**
+   * Return status of the action. This matches the enumeration in the action_msgs/msg/GoalStatus ROS message.
+   */
+  status: GoalStatus;
+  /**
+   * Return value of action. True means success, false failure.
+   */
   result: true;
 }
 
-export type RosbridgeActionResultMessage<TResultValues = unknown> =
-  | FailedRosbridgeActionResultMessage
-  | SuccessfulRosbridgeActionResultMessage<TResultValues>;
-
-export function isRosbridgeActionResultMessage<TResultValues = unknown>(
-  message: RosbridgeMessage,
-): message is RosbridgeActionResultMessage<TResultValues> {
-  return message.op === "action_result";
-}
-
-export interface RosbridgeActionStatusMessage extends RosbridgeMessage {
-  op: "action_status";
+/**
+ * A result for a ROS action.
+ */
+export interface ActionResultFailedOp extends BaseOp<"action_result"> {
+  /**
+   * If an ID was provided to the action goal, then the action result will contain the ID
+   */
   id: string;
+  /**
+   * The name of the action that was executed
+   */
   action: string;
-  status: number;
+  /**
+   * The result values. If the service had no return values, then this field can be omitted (and will be by the rosbridge server)
+   */
+  values?: string;
+  /**
+   * Return status of the action. This matches the enumeration in the action_msgs/msg/GoalStatus ROS message.
+   */
+  status: GoalStatus;
+  /**
+   * Return value of action. True means success, false failure.
+   */
+  result: false;
 }
 
-export function isRosbridgeActionStatusMessage(
-  message: RosbridgeMessage,
-): message is RosbridgeActionStatusMessage {
-  return message.op === "action_status";
+export type AnyActionOp<
+  TGoal extends object = object,
+  TFeedback extends object = object,
+  TResult extends object = object,
+> =
+  | AdvertiseActionOp
+  | UnadvertiseActionOp
+  | SendActionGoalOp<TGoal>
+  | CancelActionGoalOp
+  | ActionFeedbackOp<TFeedback>
+  | ActionResultSuccessOp<TResult>
+  | ActionResultFailedOp;
+
+//endregion
+
+// The discriminated union type for all RosBridge operations
+export type BridgeProtoOp<T extends object = object> =
+  | AuthOp
+  | FragmentOp
+  | PngOp
+  | SetStatusLevelOp
+  | StatusOp
+  | AdvertiseOp
+  | UnadvertiseOp
+  | PublishOp<T>
+  | SubscribeOp
+  | UnsubscribeOp
+  | AdvertiseServiceOp
+  | UnadvertiseServiceOp
+  | CallServiceOp<T>
+  | ServiceResponseSuccessOp<T>
+  | ServiceResponseFailedOp
+  | AdvertiseActionOp
+  | UnadvertiseActionOp
+  | SendActionGoalOp<T>
+  | CancelActionGoalOp
+  | ActionFeedbackOp<T>
+  | ActionResultSuccessOp<T>
+  | ActionResultFailedOp;
+
+export type BridgeProtoOpKey = BridgeProtoOp["op"];
+
+// Type guard to check if an unknown object is a valid BridgeProtoOp
+export function isBridgeProtoOp(obj: unknown): obj is BridgeProtoOp {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    hasOwn(obj, "op") &&
+    typeof obj.op === "string"
+  );
 }

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Type-safe wrapper for Object.hasOwn.
+ * Asserts on return that the object has the property, allowing it to be used without type complaints.
+ * @param obj The object to check.
+ * @param prop The property to check for.
+ */
+export function hasOwn<X extends object, Y extends PropertyKey>(
+  obj: X,
+  prop: Y,
+): obj is X & Record<Y, unknown> {
+  return Object.hasOwn(obj, prop);
+}

--- a/test/examples/fibonacci.example.ts
+++ b/test/examples/fibonacci.example.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import * as ROSLIB from "../../src/RosLib.js";
 
+interface FibonacciGoal {
+  order: number;
+}
+interface FibonacciResult {
+  sequence: number[];
+}
+
 // Noetic is the only version of ROS 1 we support, so we skip based on distro name
 // instead of adding extra plumbing for ROS_VERSION.
 describe.skipIf(process.env["ROS_DISTRO"] !== "noetic")(
@@ -18,7 +25,11 @@ describe.skipIf(process.env["ROS_DISTRO"] !== "noetic")(
            * ----------------
            */
 
-          const fibonacciClient = new ROSLIB.ActionClient({
+          const fibonacciClient = new ROSLIB.ActionClient<
+            FibonacciGoal,
+            FibonacciResult,
+            FibonacciResult
+          >({
             ros: ros,
             serverName: "/fibonacci",
             actionName: "actionlib_tutorials/FibonacciAction",

--- a/test/examples/topic-listener.example.ts
+++ b/test/examples/topic-listener.example.ts
@@ -12,7 +12,7 @@ const messages = ["1", "2", "3", "4"].map(format);
 
 describe("Topics Example", function () {
   function createAndStreamTopic(topicName: string) {
-    const topic = ros.Topic({
+    const topic = ros.Topic<{ data: string }>({
       name: topicName,
       messageType: "std_msgs/String",
     });
@@ -20,7 +20,11 @@ describe("Topics Example", function () {
 
     function emit() {
       setTimeout(function () {
-        topic.publish(messages[idx++]);
+        const msg = messages[idx++];
+        if (!msg) {
+          return;
+        }
+        topic.publish(msg);
         if (idx < messages.length) {
           emit();
         } else {

--- a/test/ros.test.ts
+++ b/test/ros.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "../src/core/transport/Transport.js";
 import { WebSocketTransportFactory } from "../src/core/transport/WebSocketTransportFactory.js";
 import Ros from "../src/core/Ros.js";
-import type { RosbridgeMessage } from "../src/types/protocol.js";
+import type { BridgeProtoOp } from "../src/types/protocol.js";
 
 describe("Ros", function () {
   let mockRosUrl: string;
@@ -19,7 +19,7 @@ describe("Ros", function () {
     open: ((event: TransportEvent) => void)[];
     close: ((event: TransportEvent) => void)[];
     error: ((event: TransportEvent) => void)[];
-    message: ((event: RosbridgeMessage) => void)[];
+    message: ((event: BridgeProtoOp) => void)[];
   };
 
   const publishMockTransportEvent = (event: string, value: unknown) => {
@@ -51,7 +51,7 @@ describe("Ros", function () {
         break;
       case "message":
         mockTransportListeners.message.forEach((listener) => {
-          listener(value as RosbridgeMessage);
+          listener(value as BridgeProtoOp);
         });
         break;
     }
@@ -64,7 +64,7 @@ describe("Ros", function () {
       open: new Array<(event: TransportEvent) => void>(),
       close: new Array<(event: TransportEvent) => void>(),
       error: new Array<(event: TransportEvent) => void>(),
-      message: new Array<(event: RosbridgeMessage) => void>(),
+      message: new Array<(event: BridgeProtoOp) => void>(),
     };
 
     mockTransport = {
@@ -229,7 +229,10 @@ describe("Ros", function () {
       publishMockTransportEvent("open", new Event("open"));
 
       const rosOnceSpy = vi.spyOn(ros, "once");
-      ros.callOnConnection({ op: "test" });
+
+      // Coerce this message to be a valid bridge operation (it's not)
+      // Needs to be cast because type checking will catch it otherwise
+      ros.callOnConnection({ op: "test" } as unknown as BridgeProtoOp);
 
       expect(rosOnceSpy).not.toHaveBeenCalled();
       expect(mockTransport.send).toHaveBeenCalledWith({ op: "test" });
@@ -242,7 +245,10 @@ describe("Ros", function () {
 
       // When disconnected, the message is queued to send
       const rosOnceSpy = vi.spyOn(ros, "once");
-      ros.callOnConnection({ op: "test" });
+
+      // Coerce this message to be a valid bridge operation (it's not)
+      // Needs to be cast because type checking will catch it otherwise
+      ros.callOnConnection({ op: "test" } as unknown as BridgeProtoOp);
 
       expect(rosOnceSpy).toHaveBeenCalledWith("open", expect.any(Function));
       expect(mockTransport.send).not.toHaveBeenCalled();

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -37,10 +37,7 @@ describe("Service", () => {
     expect(ros.listenerCount(server.name)).toEqual(0);
   });
   it("Successfully advertises a service with a synchronous return", async () => {
-    const server = new Service<
-      undefined,
-      { success: boolean; message: string }
-    >({
+    const server = new Service<never, { success: boolean; message: string }>({
       ros,
       serviceType: "std_srvs/Trigger",
       name: "/test_service",
@@ -71,10 +68,7 @@ describe("Service", () => {
   });
 
   it("Handles re-advertisement gracefully without throwing errors", async () => {
-    const server = new Service<
-      undefined,
-      { success: boolean; message: string }
-    >({
+    const server = new Service<never, { success: boolean; message: string }>({
       ros,
       serviceType: "std_srvs/Trigger",
       name: "/test_readvertise",
@@ -106,10 +100,7 @@ describe("Service", () => {
   });
 
   it("Handles multiple unadvertise calls gracefully", async () => {
-    const server = new Service<
-      undefined,
-      { success: boolean; message: string }
-    >({
+    const server = new Service<never, { success: boolean; message: string }>({
       ros,
       serviceType: "std_srvs/Trigger",
       name: "/test_multiple_unadvertise",
@@ -164,10 +155,7 @@ describe("Service", () => {
   });
 
   it("Ensures operations are serialized through queue", async () => {
-    const server = new Service<
-      undefined,
-      { success: boolean; message: string }
-    >({
+    const server = new Service<never, { success: boolean; message: string }>({
       ros,
       serviceType: "std_srvs/Trigger",
       name: "/test_queue",

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -4,16 +4,13 @@ import type { MockedObject } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AbstractTransport } from "../src/core/transport/Transport.js";
 import { WebSocketTransportFactory } from "../src/core/transport/WebSocketTransportFactory.js";
-import type {
-  RosbridgeMessage,
-  RosbridgePngMessage,
-} from "../src/types/protocol.js";
 import CBOR from "cbor-js";
 import * as fastpng from "fast-png";
 import * as bson from "bson";
 import * as ws from "ws";
 import { NativeWebSocketTransport } from "../src/core/transport/NativeWebSocketTransport.js";
 import { WsWebSocketTransport } from "../src/core/transport/WsWebSocketTransport.js";
+import type { BridgeProtoOp } from "../src/types/protocol.js";
 
 vi.mock("fast-png");
 
@@ -55,9 +52,9 @@ describe("Transport", () => {
     });
 
     it("should handle RosbridgeMessage", () => {
-      const message: RosbridgeMessage = {
+      const message = {
         op: "test",
-      };
+      } as unknown as BridgeProtoOp;
 
       const messageEvent: Partial<MessageEvent> = {
         type: "message",
@@ -202,12 +199,12 @@ describe("Transport", () => {
 
       // Obviously these are not real PNG encoded messages.
       // But they're good enough for mocking responses in our tests.
-      const successMessage: RosbridgePngMessage = {
+      const successMessage = {
         op: "png",
         data: Buffer.from("success").toString("base64"),
       };
 
-      const failureMessage: RosbridgePngMessage = {
+      const failureMessage = {
         op: "png",
         data: Buffer.from("failure").toString("base64"),
       };
@@ -370,7 +367,7 @@ describe("Transport", () => {
     it("should send messages as JSON", () => {
       const transport = new NativeWebSocketTransport(mockSocket);
 
-      transport.send({ op: "test" });
+      transport.send({ op: "test" } as unknown as BridgeProtoOp);
 
       expect(mockSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ op: "test" }),
@@ -482,9 +479,9 @@ describe("Transport", () => {
 
       transport.on("message", messageListener);
 
-      const message: RosbridgeMessage = {
+      const message = {
         op: "test",
-      };
+      } as unknown as BridgeProtoOp;
 
       const messageEvent: Partial<MessageEvent> = {
         type: "message",
@@ -515,7 +512,7 @@ describe("Transport", () => {
     it("should send messages as JSON", () => {
       const transport = new WsWebSocketTransport(mockSocket);
 
-      transport.send({ op: "test" });
+      transport.send({ op: "test" } as unknown as BridgeProtoOp);
 
       expect(mockSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ op: "test" }),
@@ -627,9 +624,9 @@ describe("Transport", () => {
 
       transport.on("message", messageListener);
 
-      const message: RosbridgeMessage = {
+      const message = {
         op: "test",
-      };
+      } as unknown as BridgeProtoOp;
 
       const messageEvent: ws.MessageEvent = {
         type: "message",


### PR DESCRIPTION
**Public API Changes**
None


**Description**
While the typing work was extensive to represent the RosBridge protocol, there were some things that were overlooked in the migration that meant that the type checking both for the developers of this library, and the types delivered to developers working with the lib weren't exhaustive.  
This PR addresses this by refactoring the protocol files:
* Add the documentation from the ROSBridge protocol doc to aid developers which took forever but is worth it (at least for me)
* Create union types both for subsections of the protocol, but also every possible operation. This means that type checking can be narrowed just by checking the 'op' field without having to have a guard method for each operation.
* Fixes some discrepancies that arose as a result of the non-exhaustive checking.
* Allows a distinction between outgoing and incoming service call messages, which takes care of the TODO left by Ezra w.r.t being deep partial on the way out but required on the way in.
* Allows inference on emitter types for special name topic strings like service call and action callback messages.

Apologies for the name changes, I had this left over from another PR I didn't get to complete and the scheme was completely different from yours.

This PR also does some housekeeping on complex methods with large Cyclomatic Complexity, making them easier to read and maintain. In particular, `Service#advertise` and `advertiseAsync` have a common parent function now, joining the common parts together.

I also split out some of the longer that were declared right in function parameters, which makes them harder to read and follow when you have a large object in the constructor.

As always, thanks for the consideration and happy to address any comments :)


<!-- Link relevant GitHub issues -->
Fixes #1068 
Fixes #1069 