### PR TITLE
Treat warnings as errors in typedoc, expose missing public APIs to fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ Install roslibjs with any NPM-compatible package manager via, for example,
 npm install roslib
 ```
 
-~Pre-built files can be found in either [roslib.js](build/roslib.js) or [roslib.min.js](build/roslib.min.js).~
-
-As we are updating to v2, we don't provide pre-built files anymore in the repo.
-
-Alternatively, you can use the v1 release via the [JsDelivr](https://www.jsdelivr.com/) CDN: ([full](https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js)) | ([min](https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.min.js))
-
 ## Troubleshooting
 
 1. Check that connection is established. You can listen to error and
@@ -31,8 +25,12 @@ Alternatively, you can use the v1 release via the [JsDelivr](https://www.jsdeliv
    examples/simple.html for a complete example:
 
    ```js
-   ros.on('error', function(error) { console.log( error ); });
-   ros.on('connection', function() { console.log('Connection made!'); });
+   ros.on("error", function (error) {
+     console.log(error);
+   });
+   ros.on("connection", function () {
+     console.log("Connection made!");
+   });
    ```
 
 2. Check that you have the websocket server is running on

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "doc": "typedoc src/RosLib.ts",
+    "doc": "typedoc src/RosLib.ts --treatWarningsAsErrors",
     "lint": "eslint .",
     "test": "vitest",
     "prepublishOnly": "npm run test",

--- a/src/RosLib.ts
+++ b/src/RosLib.ts
@@ -6,11 +6,12 @@
 export const REVISION = import.meta.env.VITE_ROSLIBJS_VERSION;
 
 // Core exports
-export { default as Ros } from "./core/Ros.js";
+export { default as Ros, type TypeDefDict } from "./core/Ros.js";
 export { default as Topic } from "./core/Topic.js";
 export { default as Param } from "./core/Param.js";
 export { default as Service } from "./core/Service.js";
 export { default as Action } from "./core/Action.js";
+export { type GoalStatus } from "./core/GoalStatus.js";
 
 // Core Transport exports
 export {
@@ -53,6 +54,7 @@ export {
   default as UrdfVisual,
   type UrdfGeometryLike,
 } from "./urdf/UrdfVisual.js";
+export { default as UrdfJoint } from "./urdf/UrdfJoint.js";
 
 export {
   UrdfAttrs,
@@ -60,3 +62,20 @@ export {
   type UrdfDefaultOptions,
 } from "./urdf/UrdfTypes.js";
 export { isElement, parseUrdfOrigin } from "./urdf/UrdfUtils.js";
+
+// only export the types that typedoc requires us to export - those are our public interfaces
+export { type actionlib_msgs } from "./types/actionlib_msgs.js";
+export { type tf2_web_republisher } from "./types/tf2_web_republisher.js";
+export { type rosapi } from "./types/rosapi.js";
+export { type std_msgs } from "./types/std_msgs.js";
+export { type tf2_msgs } from "./types/tf2_msgs.js";
+export { type geometry_msgs } from "./types/geometry_msgs.js";
+export type { Nullable, PartialNullable } from "./types/interface-types.js";
+export {
+  type RosbridgeMessage,
+  isRosbridgeMessage,
+  type RosbridgeAdvertiseMessage,
+  isRosbridgeAdvertiseMessage,
+  type RosbridgeSubscribeMessage,
+  isRosbridgeSubscribeMessage,
+} from "./types/protocol.js";

--- a/src/RosLib.ts
+++ b/src/RosLib.ts
@@ -1,9 +1,8 @@
 /**
- * @fileOverview
  * @author Russell Toris - rctoris@wpi.edu
  */
 
-/** @description Library version */
+/** Library version */
 export const REVISION = import.meta.env.VITE_ROSLIBJS_VERSION;
 
 // Core exports

--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -33,7 +33,7 @@ import type {
 } from "./transport/Transport.js";
 import { WebSocketTransportFactory } from "./transport/WebSocketTransportFactory.ts";
 
-interface TypeDefDict {
+export interface TypeDefDict {
   [key: string]: string | string[] | TypeDefDict | TypeDefDict[];
 }
 

--- a/src/types/rosapi.ts
+++ b/src/types/rosapi.ts
@@ -30,15 +30,15 @@ export namespace rosapi {
     name: string;
     default?: string;
   }
-  interface GetParamResponsePreJazzy {
+  export interface GetParamResponsePreJazzy {
     value: string;
   }
-  interface GetParamResponseFailedPostJazzy {
+  export interface GetParamResponseFailedPostJazzy {
     value: never;
     successful: false;
     reason: string;
   }
-  interface GetParamResponseSuccessPostJazzy {
+  export interface GetParamResponseSuccessPostJazzy {
     value: string;
     successful: true;
     reason: never;
@@ -51,12 +51,12 @@ export namespace rosapi {
     name: string;
     value: string;
   }
-  type SetParamResponsePreJazzy = Record<never, never>;
-  interface FailedSetParamResponsePostJazzy {
+  export type SetParamResponsePreJazzy = Record<never, never>;
+  export interface FailedSetParamResponsePostJazzy {
     successful: false;
     reason: string;
   }
-  interface SuccessfulSetParamResponsePostJazzy {
+  export interface SuccessfulSetParamResponsePostJazzy {
     successful: true;
     reason: never;
   }
@@ -67,12 +67,12 @@ export namespace rosapi {
   export interface DeleteParamRequest {
     name: string;
   }
-  type DeleteParamResponsePreJazzy = Record<never, never>;
-  interface FailedDeleteParamResponsePostJazzy {
+  export type DeleteParamResponsePreJazzy = Record<never, never>;
+  export interface FailedDeleteParamResponsePostJazzy {
     successful: false;
     reason: string;
   }
-  interface SuccessfulDeleteParamResponsePostJazzy {
+  export interface SuccessfulDeleteParamResponsePostJazzy {
     successful: true;
     reason: never;
   }


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

Exposed some missing TypeScript types.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

^

<!-- Link relevant GitHub issues -->
