### PR TITLE
Ban function binding

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -31,6 +31,14 @@ export default defineConfig(
       "@typescript-eslint/no-empty-function": 0,
       "prefer-template": 2,
       "@typescript-eslint/consistent-type-imports": 2,
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "CallExpression[callee.property.name='bind']",
+          message:
+            "Prefer arrow functions over invoking Function.prototype.bind",
+        },
+      ],
     },
   },
   {

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -126,7 +126,7 @@ export default class Action<
     this.#cancelCallback = cancelCallback;
     this.ros.on(this.name, (msg) => {
       if (isRosbridgeSendActionGoalMessage(msg)) {
-        this.#executeAction.bind(this);
+        this.#executeAction(msg);
       } else {
         throw new Error(
           "Received unrelated message on Action server event stream!",

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -125,7 +125,7 @@ export default class Action<
     this.#actionCallback = actionCallback;
     this.#cancelCallback = cancelCallback;
     this.ros.on(this.name, (msg) => {
-      if (isRosbridgeSendActionGoalMessage(msg)) {
+      if (isRosbridgeSendActionGoalMessage<TGoal>(msg)) {
         this.#executeAction(msg);
       } else {
         throw new Error(

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -260,9 +260,9 @@ export interface RosbridgeSendActionGoalMessage<TArgs = unknown>
   compression?: string;
 }
 
-export function isRosbridgeSendActionGoalMessage(
+export function isRosbridgeSendActionGoalMessage<TArgs = unknown>(
   message: RosbridgeMessageBase,
-): message is RosbridgeSendActionGoalMessage {
+): message is RosbridgeSendActionGoalMessage<TArgs> {
   return message.op === "send_action_goal";
 }
 


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Fixes #1068 by further modernizing our codebase to disallow function binding, which is largely obsolete in the era of arrow functions.

The one remaining place it was being used wasn't even necessary 🤦🏻 

<!-- Link relevant GitHub issues -->
