### PR TITLE
Rearrange GitHub Actions to allow publishing to NPM

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,29 @@
+name: CD
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: read
+  id-token: write # Required to authenticate with npm
+
+jobs:
+  docs:
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+    with:
+      deploy: true
+
+  publish:
+    environment: npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,21 @@
 name: Docs Deployment
 
 on:
-  pull_request:
-  push:
-    branches:
-      - develop
-  release:
-    types: [released]
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Deploy to GitHub Pages"
+        required: true
+        type: boolean
+        default: false
+
+  workflow_call:
+    inputs:
+      deploy:
+        description: "Deploy to GitHub Pages"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -39,7 +47,7 @@ jobs:
       # pages and id-token required to deploy to GitHub Pages
       pages: write
       id-token: write
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: inputs.deploy
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,9 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  docs:
+    uses: ./.github/workflows/docs.yml
+    secrets: inherit
+    with:
+      deploy: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,4 @@
-# Robot Web Tools Module Release TODOs
-
-This document describes TODOs and checklists in order to release
-Robot Web Tool javascript modules([roslibjs](https://github.com/RobotWebTools/roslibjs), [ros2djs](https://github.com/RobotWebTools/ros2djs), [ros3djs](https://github.com/RobotWebTools/ros3djs)).
+# How to release roslibjs
 
 ## 0. Make sure that the releasing module is compatible with other RWT modules
 
@@ -13,36 +10,14 @@ docker run -it --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator
 
 ## 2. Bump a new version
 
-* Version bump in package.json, bower.json, and in the main file. e.g) [RosLib.js](src/RosLib.js)
+* Version bump in [package.json](./package.json)
 * Tag the version
 
-## 3. Release modules
-
-### NPM
-
-Publish the module. We publish in the global scope.
-
-* `npm publish`
-
-### CDN
-
-Hosted via the [JsDelivr](https://www.jsdelivr.com/) CDN, which takes it directly from the repo.
-
-## 4. Create GitHub Release
+## 3. Create GitHub Release
 
 * Create a new GitHub release based on the new git tag.
 * Add the version number as release title (Without leading `v`).
 * Let GitHub auto-generate the Changelog
 * Mark `Set as latest release`
 * Publish release
-
-## 5. Update JSdocs in Robot Web Tools website
-
-The JSdocs are update automatically by GitHub Actions [config](.github/workflows/docs.yml). The GitHub release created above, will trigger this run. The docs are hosted in their own repository at the `gh-pages` branch.
-
-## 6. Sync `develop` branch with `master`
-
-`Master` branch should represent the latest release.
-
-* Create a PR against `master` from `develop`
-* Do *Rebase and merge* to have the same history as `develop` branch
+* [The CD action](.github/workflows/cd.yml) will automatically publish the docs to the website and publish the package to npm.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roslib",
   "homepage": "https://robotwebtools.github.io",
   "description": "The standard ROS Javascript Library",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha1",
   "license": "BSD-2-Clause",
   "files": [
     "dist"


### PR DESCRIPTION
also temporarily set the package.json version to 2.0.0-alpha1 so I don't accidentally clobber the 2.0.0 version while testing
