### PR TITLE
Remove double build in CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,5 +28,4 @@ jobs:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm run build
       - run: npm publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
 
-      - name: Build JavaScript library
-        run: npm run build
-
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
We run `build` during `npm prepare`, which means it's already run implicitly during the `npm ci` step that already exists in these jobs.