### PR TITLE
Fix repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roslib",
   "homepage": "https://robotwebtools.github.io",
   "description": "The standard ROS Javascript Library",
-  "version": "2.0.0-alpha4",
+  "version": "2.0.0-alpha5",
   "license": "BSD-2-Clause",
   "files": [
     "dist"
@@ -68,7 +68,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/RobotWebTools/roslibjs/releases"
+    "url": "https://github.com/RobotWebTools/roslibjs"
   },
   "bugs": {
     "url": "https://github.com/RobotWebTools/roslibjs/issues"


### PR DESCRIPTION
NPM rejected the publish because this URL mismatched the GitHub repo we were pushing from an Action on.
