### PR TITLE
Use standard Uint8Array instead of Node.js Buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@xmldom/xmldom": "^0.9.8",
         "bson": "^7.0.0",
-        "buffer": "^6.0.3",
         "cbor2": "^2.0.1",
         "eventemitter3": "^5.0.1",
         "fast-png": "^7.0.1",
@@ -3058,6 +3057,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3161,30 +3161,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5360,6 +5336,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@xmldom/xmldom": "^0.9.8",
     "bson": "^7.0.0",
-    "buffer": "^6.0.3",
     "cbor2": "^2.0.1",
     "eventemitter3": "^5.0.1",
     "fast-png": "^7.0.1",

--- a/src/util/decompressPng.ts
+++ b/src/util/decompressPng.ts
@@ -5,7 +5,6 @@
 
 import type { DecodedPng } from "fast-png";
 import { decode } from "fast-png";
-import { Buffer } from "buffer";
 
 const textDecoder = new TextDecoder();
 
@@ -17,7 +16,7 @@ const textDecoder = new TextDecoder();
  * @param data - An object containing the PNG data.
  */
 export default function decompressPng(data: string): unknown {
-  const buffer = Buffer.from(data, "base64");
+  const buffer = Uint8Array.from(atob(data), (char) => char.charCodeAt(0));
 
   const decoded = tryDecodeBuffer(buffer);
 
@@ -28,7 +27,7 @@ export default function decompressPng(data: string): unknown {
   }
 }
 
-function tryDecodeBuffer(buffer: Buffer): DecodedPng {
+function tryDecodeBuffer(buffer: Uint8Array): DecodedPng {
   try {
     return decode(buffer);
   } catch (error) {

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -190,7 +190,7 @@ describe("Transport", () => {
             text: {},
             data: Buffer.from(JSON.stringify({ op: "test" })),
           };
-          switch ((data as Buffer).toString()) {
+          switch (new TextDecoder().decode(data)) {
             case "success":
               return decodedImage;
             case "failure":


### PR DESCRIPTION
fixes #1098 

more removing ancient dependencies (that aren't exposed in our API) as I run through real-world usage of roslibjs 2.0 and encounter hurdles.