### PR TITLE
Fix: Check status code in Action.sendGoal instead of result field

### DIFF
--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -14,34 +14,6 @@ import {
 import type Ros from "./Ros.ts";
 import { v4 as uuidv4 } from "uuid";
 
-export class GoalError extends Error {
-  constructor(status: GoalStatus | number | string, baseError?: unknown) {
-    const base = typeof baseError === "string" ? baseError : "";
-    let message: string;
-
-    switch (status) {
-      case GoalStatus.STATUS_CANCELED:
-        message = `Action was canceled${base ? `: ${base}` : ""}`;
-        break;
-      case GoalStatus.STATUS_ABORTED:
-        message = `Action was aborted${base ? `: ${base}` : ""}`;
-        break;
-      case GoalStatus.STATUS_CANCELING:
-        message = `Action is canceling${base ? `: ${base}` : ""}`;
-        break;
-      case GoalStatus.STATUS_UNKNOWN:
-        message = `Action status unknown${base ? `: ${base}` : ""}`;
-        break;
-      default:
-        message = `Action failed with status ${String(status)}${base ? `: ${base}` : ""}`;
-    }
-
-    super(message);
-    this.name = "GoalError";
-    Object.setPrototypeOf(this, GoalError.prototype);
-  }
-}
-
 /**
  * A ROS 2 action client.
  */
@@ -101,12 +73,32 @@ export default class Action<
       if (isRosbridgeActionResultMessage<TResult>(message)) {
         const status = message.status as GoalStatus;
 
-        // Validates both status and result
+        // Check status code instead of result field to properly handle STATUS_CANCELED
         if (status === GoalStatus.STATUS_SUCCEEDED && message.result) {
           resultCallback(message.values);
         } else {
-          const errorMessage: GoalError = new GoalError(status, message.values);
-          failedCallback(String(errorMessage));
+          const baseError =
+            typeof message.values === "string" ? message.values : "";
+
+          let errorMessage: string;
+          switch (status) {
+            case GoalStatus.STATUS_CANCELED:
+              errorMessage = `Action was canceled${baseError ? `: ${baseError}` : ""}`;
+              break;
+            case GoalStatus.STATUS_ABORTED:
+              errorMessage = `Action was aborted${baseError ? `: ${baseError}` : ""}`;
+              break;
+            case GoalStatus.STATUS_CANCELING:
+              errorMessage = `Action is canceling${baseError ? `: ${baseError}` : ""}`;
+              break;
+            case GoalStatus.STATUS_UNKNOWN:
+              errorMessage = `Action status unknown${baseError ? `: ${baseError}` : ""}`;
+              break;
+            default:
+              errorMessage = `Action failed with status ${String(status)}${baseError ? `: ${baseError}` : ""}`;
+          }
+
+          failedCallback(errorMessage);
         }
       } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
         feedbackCallback?.(message.values);

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -14,6 +14,28 @@ import {
 import type Ros from "./Ros.ts";
 import { v4 as uuidv4 } from "uuid";
 
+class GoalError extends Error {
+  override name = "GoalError";
+  constructor(status: GoalStatus, errorValue?: string) {
+    super(`${makeErrorMessage(status)}${errorValue ? `: ${errorValue}` : ""}`);
+  }
+}
+
+function makeErrorMessage(status: GoalStatus) {
+  switch (status) {
+    case GoalStatus.STATUS_CANCELED:
+      return `Action was canceled`;
+    case GoalStatus.STATUS_ABORTED:
+      return `Action was aborted`;
+    case GoalStatus.STATUS_CANCELING:
+      return `Action is canceling`;
+    case GoalStatus.STATUS_UNKNOWN:
+      return `Action status unknown`;
+    default:
+      return `Action failed with status ${String(status)}`;
+  }
+}
+
 /**
  * A ROS 2 action client.
  */
@@ -73,32 +95,15 @@ export default class Action<
       if (isRosbridgeActionResultMessage<TResult>(message)) {
         const status = message.status as GoalStatus;
 
-        // Check status code instead of result field to properly handle STATUS_CANCELED
-        if (status === GoalStatus.STATUS_SUCCEEDED && message.result) {
-          resultCallback(message.values);
+        if (!message.result) {
+          failedCallback(String(new GoalError(status, message.values)));
+        } else if (status !== GoalStatus.STATUS_SUCCEEDED) {
+          failedCallback(
+            String(new GoalError(status, JSON.stringify(message.values))),
+          );
+          // Check status code instead of result field to properly handle STATUS_CANCELED
         } else {
-          const baseError =
-            typeof message.values === "string" ? message.values : "";
-
-          let errorMessage: string;
-          switch (status) {
-            case GoalStatus.STATUS_CANCELED:
-              errorMessage = `Action was canceled${baseError ? `: ${baseError}` : ""}`;
-              break;
-            case GoalStatus.STATUS_ABORTED:
-              errorMessage = `Action was aborted${baseError ? `: ${baseError}` : ""}`;
-              break;
-            case GoalStatus.STATUS_CANCELING:
-              errorMessage = `Action is canceling${baseError ? `: ${baseError}` : ""}`;
-              break;
-            case GoalStatus.STATUS_UNKNOWN:
-              errorMessage = `Action status unknown${baseError ? `: ${baseError}` : ""}`;
-              break;
-            default:
-              errorMessage = `Action failed with status ${String(status)}${baseError ? `: ${baseError}` : ""}`;
-          }
-
-          failedCallback(errorMessage);
+          resultCallback(message.values);
         }
       } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
         feedbackCallback?.(message.values);

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -14,6 +14,34 @@ import {
 import type Ros from "./Ros.ts";
 import { v4 as uuidv4 } from "uuid";
 
+export class GoalError extends Error {
+  constructor(status: GoalStatus | number | string, baseError?: unknown) {
+    const base = typeof baseError === "string" ? baseError : "";
+    let message: string;
+
+    switch (status) {
+      case GoalStatus.STATUS_CANCELED:
+        message = `Action was canceled${base ? `: ${base}` : ""}`;
+        break;
+      case GoalStatus.STATUS_ABORTED:
+        message = `Action was aborted${base ? `: ${base}` : ""}`;
+        break;
+      case GoalStatus.STATUS_CANCELING:
+        message = `Action is canceling${base ? `: ${base}` : ""}`;
+        break;
+      case GoalStatus.STATUS_UNKNOWN:
+        message = `Action status unknown${base ? `: ${base}` : ""}`;
+        break;
+      default:
+        message = `Action failed with status ${String(status)}${base ? `: ${base}` : ""}`;
+    }
+
+    super(message);
+    this.name = "GoalError";
+    Object.setPrototypeOf(this, GoalError.prototype);
+  }
+}
+
 /**
  * A ROS 2 action client.
  */
@@ -73,32 +101,12 @@ export default class Action<
       if (isRosbridgeActionResultMessage<TResult>(message)) {
         const status = message.status as GoalStatus;
 
-        // Check status code instead of result field to properly handle STATUS_CANCELED
+        // Validates both status and result
         if (status === GoalStatus.STATUS_SUCCEEDED && message.result) {
           resultCallback(message.values);
         } else {
-          const baseError =
-            typeof message.values === "string" ? message.values : "";
-
-          let errorMessage: string;
-          switch (status) {
-            case GoalStatus.STATUS_CANCELED:
-              errorMessage = `Action was canceled${baseError ? `: ${baseError}` : ""}`;
-              break;
-            case GoalStatus.STATUS_ABORTED:
-              errorMessage = `Action was aborted${baseError ? `: ${baseError}` : ""}`;
-              break;
-            case GoalStatus.STATUS_CANCELING:
-              errorMessage = `Action is canceling${baseError ? `: ${baseError}` : ""}`;
-              break;
-            case GoalStatus.STATUS_UNKNOWN:
-              errorMessage = `Action status unknown${baseError ? `: ${baseError}` : ""}`;
-              break;
-            default:
-              errorMessage = `Action failed with status ${String(status)}${baseError ? `: ${baseError}` : ""}`;
-          }
-
-          failedCallback(errorMessage);
+          const errorMessage: GoalError = new GoalError(status, message.values);
+          failedCallback(String(errorMessage));
         }
       } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
         feedbackCallback?.(message.values);

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -69,19 +69,41 @@ export default class Action<
     }
 
     const actionGoalId = `send_action_goal:${this.name}:${uuidv4()}`;
-
-    this.ros.on(actionGoalId, function (message) {
+    this.ros.on(actionGoalId, (message) => {
       if (isRosbridgeActionResultMessage<TResult>(message)) {
-        if (!message.result) {
-          failedCallback(message.values ?? "");
+        const status = message.status as GoalStatus;
+
+        // Check status code instead of result field to properly handle STATUS_CANCELED
+        if (status === GoalStatus.STATUS_SUCCEEDED) {
+          resultCallback(message.values as TResult);
         } else {
-          resultCallback(message.values);
+          const baseError =
+            typeof message.values === "string" ? message.values : "";
+
+          let errorMessage: string;
+          switch (status) {
+            case GoalStatus.STATUS_CANCELED:
+              errorMessage = `Action was canceled${baseError ? `: ${baseError}` : ""}`;
+              break;
+            case GoalStatus.STATUS_ABORTED:
+              errorMessage = `Action was aborted${baseError ? `: ${baseError}` : ""}`;
+              break;
+            case GoalStatus.STATUS_CANCELING:
+              errorMessage = `Action is canceling${baseError ? `: ${baseError}` : ""}`;
+              break;
+            case GoalStatus.STATUS_UNKNOWN:
+              errorMessage = `Action status unknown${baseError ? `: ${baseError}` : ""}`;
+              break;
+            default:
+              errorMessage = `Action failed with status ${String(status)}${baseError ? `: ${baseError}` : ""}`;
+          }
+
+          failedCallback(errorMessage);
         }
       } else if (isRosbridgeActionFeedbackMessage<TFeedback>(message)) {
         feedbackCallback?.(message.values);
       }
     });
-
     this.ros.callOnConnection({
       op: "send_action_goal",
       id: actionGoalId,

--- a/src/core/Action.ts
+++ b/src/core/Action.ts
@@ -74,8 +74,8 @@ export default class Action<
         const status = message.status as GoalStatus;
 
         // Check status code instead of result field to properly handle STATUS_CANCELED
-        if (status === GoalStatus.STATUS_SUCCEEDED) {
-          resultCallback(message.values as TResult);
+        if (status === GoalStatus.STATUS_SUCCEEDED && message.result) {
+          resultCallback(message.values);
         } else {
           const baseError =
             typeof message.values === "string" ? message.values : "";

--- a/test/actionSendgoal.test.ts
+++ b/test/actionSendgoal.test.ts
@@ -1,0 +1,318 @@
+/**
+ * @fileOverview
+ * Test for Action.sendGoal status code handling
+ * Tests that sendGoal properly handles STATUS_CANCELED and other status codes
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Action from "../src/core/Action.ts";
+import { GoalStatus } from "../src/core/GoalStatus.ts";
+import type Ros from "../src/core/Ros.ts";
+
+// Strict types matching the real protocol
+interface ActionResultMessageBase {
+  op: "action_result";
+  id: string;
+  action: string;
+  status: number;
+}
+
+interface FailedActionResultMessage extends ActionResultMessageBase {
+  result: false;
+  values?: string;
+}
+
+interface SuccessfulActionResultMessage extends ActionResultMessageBase {
+  result: true;
+  values: { result: number };
+}
+
+type ActionResultMessage =
+  | FailedActionResultMessage
+  | SuccessfulActionResultMessage;
+
+interface ActionFeedbackMessage {
+  op: "action_feedback";
+  id: string;
+  action: string;
+  values: { current: number };
+}
+
+type ActionMessage = ActionResultMessage | ActionFeedbackMessage;
+
+describe("Action.sendGoal", () => {
+  let action: Action<
+    { target: number },
+    { current: number },
+    { result: number }
+  >;
+  let mockRos: Ros;
+  let messageHandler: ((msg: ActionMessage) => void) | null = null;
+
+  beforeEach(() => {
+    messageHandler = null;
+    mockRos = {
+      on: vi.fn((_id: string, callback: (msg: ActionMessage) => void) => {
+        messageHandler = callback;
+      }),
+      callOnConnection: vi.fn(),
+    } as unknown as Ros;
+
+    action = new Action({
+      ros: mockRos,
+      name: "/test_action",
+      actionType: "test_msgs/TestAction",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("status code handling", () => {
+    it("should call resultCallback when action succeeds (STATUS_SUCCEEDED)", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      const successMessage: SuccessfulActionResultMessage = {
+        op: "action_result",
+        id: "test-id",
+        action: "/test_action",
+        values: { result: 42 },
+        status: GoalStatus.STATUS_SUCCEEDED,
+        result: true,
+      };
+
+      messageHandler?.(successMessage);
+
+      expect(resultCallback).toHaveBeenCalledWith({ result: 42 });
+      expect(failedCallback).not.toHaveBeenCalled();
+    });
+
+    it("should call failedCallback when action is cancelled (STATUS_CANCELED)", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      const cancelledMessage: FailedActionResultMessage = {
+        op: "action_result",
+        id: "test-id",
+        action: "/test_action",
+        values: "Action was cancelled by user",
+        status: GoalStatus.STATUS_CANCELED,
+        result: false,
+      };
+
+      messageHandler?.(cancelledMessage);
+
+      expect(failedCallback).toHaveBeenCalled();
+      expect(resultCallback).not.toHaveBeenCalled();
+    });
+
+    it("should call failedCallback when action is aborted (STATUS_ABORTED)", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      const abortedMessage: FailedActionResultMessage = {
+        op: "action_result",
+        id: "test-id",
+        action: "/test_action",
+        values: "Action aborted due to error",
+        status: GoalStatus.STATUS_ABORTED,
+        result: false,
+      };
+
+      messageHandler?.(abortedMessage);
+
+      expect(failedCallback).toHaveBeenCalled();
+      expect(resultCallback).not.toHaveBeenCalled();
+    });
+
+    it("should call failedCallback when action is canceling (STATUS_CANCELING)", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      const cancelingMessage: FailedActionResultMessage = {
+        op: "action_result",
+        id: "test-id",
+        action: "/test_action",
+        values: "Action is being cancelled",
+        status: GoalStatus.STATUS_CANCELING,
+        result: false,
+      };
+
+      messageHandler?.(cancelingMessage);
+
+      expect(failedCallback).toHaveBeenCalled();
+      expect(resultCallback).not.toHaveBeenCalled();
+    });
+
+    it("should handle unknown status gracefully (STATUS_UNKNOWN)", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      const unknownMessage: FailedActionResultMessage = {
+        op: "action_result",
+        id: "test-id",
+        action: "/test_action",
+        values: "Unknown status",
+        status: GoalStatus.STATUS_UNKNOWN,
+        result: false,
+      };
+
+      messageHandler?.(unknownMessage);
+
+      expect(failedCallback).toHaveBeenCalled();
+      expect(resultCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("feedback handling", () => {
+    it("should handle feedback messages correctly", () => {
+      const resultCallback = vi.fn();
+      const feedbackCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        feedbackCallback,
+        failedCallback,
+      );
+
+      const feedbackMessage: ActionFeedbackMessage = {
+        op: "action_feedback",
+        id: "test-id",
+        action: "/test_action",
+        values: { current: 5 },
+      };
+
+      messageHandler?.(feedbackMessage);
+
+      expect(feedbackCallback).toHaveBeenCalledWith({ current: 5 });
+      expect(resultCallback).not.toHaveBeenCalled();
+      expect(failedCallback).not.toHaveBeenCalled();
+    });
+
+    it("should handle multiple feedback messages", () => {
+      const resultCallback = vi.fn();
+      const feedbackCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        feedbackCallback,
+        failedCallback,
+      );
+
+      const feedbackMessage1: ActionFeedbackMessage = {
+        op: "action_feedback",
+        id: "test-id",
+        action: "/test_action",
+        values: { current: 3 },
+      };
+
+      const feedbackMessage2: ActionFeedbackMessage = {
+        op: "action_feedback",
+        id: "test-id",
+        action: "/test_action",
+        values: { current: 7 },
+      };
+
+      messageHandler?.(feedbackMessage1);
+      messageHandler?.(feedbackMessage2);
+
+      expect(feedbackCallback).toHaveBeenCalledTimes(2);
+      expect(feedbackCallback).toHaveBeenNthCalledWith(1, { current: 3 });
+      expect(feedbackCallback).toHaveBeenNthCalledWith(2, { current: 7 });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should prioritize status code over result field", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      // This is the problematic case: result=true but status=CANCELED
+      // According to protocol, this shouldn't happen, but we test it anyway
+      // We have to cast to test this edge case since TypeScript prevents it
+      const confusingMessage = {
+        op: "action_result",
+        id: "test-id",
+        action: "/test_action",
+        values: { result: 0 },
+        status: GoalStatus.STATUS_CANCELED,
+        result: true, // This violates the type but could happen at runtime
+      } as ActionMessage;
+
+      messageHandler?.(confusingMessage);
+
+      // Should call failedCallback because status is CANCELED
+      expect(failedCallback).toHaveBeenCalled();
+      expect(resultCallback).not.toHaveBeenCalled();
+    });
+
+    it("should handle missing feedback callback gracefully", () => {
+      const resultCallback = vi.fn();
+      const failedCallback = vi.fn();
+
+      action.sendGoal(
+        { target: 10 },
+        resultCallback,
+        undefined,
+        failedCallback,
+      );
+
+      const feedbackMessage: ActionFeedbackMessage = {
+        op: "action_feedback",
+        id: "test-id",
+        action: "/test_action",
+        values: { current: 5 },
+      };
+
+      expect(() => messageHandler?.(feedbackMessage)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->


**Description**

I fixed a bug in `Action.sendGoal` where the method was checking the `result` field instead of the `status` field to determine action success/failure. This caused `STATUS_CANCELED` and other status codes to be handled incorrectly.

After reading the documentation, I realized that action result messages contain two fields:
- `result` : A simplified success/failure indicator  
- `status` : The authoritative status 

I updated the `sendGoal` method in `src/core/Action.ts` to check `message.status` against `GoalStatus.STATUS_SUCCEEDED` as the primary indicator of success. For all other status values, I route to the failure callback with descriptive error messages based on the specific status code.
```typescript
// Check status code instead of result field
const status = message.status as GoalStatus;

if (status === GoalStatus.STATUS_SUCCEEDED) {
  resultCallback(message.values as TResult);
} else {
  // Handle failures with appropriate error messages
  failedCallback(errorMessage);
}
```

### Testing

I added comprehensive unit tests in `test/actionSendgoal.test.ts` covering:
- GoalStatus values (SUCCEEDED, CANCELED, ABORTED, CANCELING, UNKNOWN)
- Feedback message handling
- Edge case where `result` and `status` fields contradict each other


### References

- [Rosbridge Protocol - Action Result](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/ROSBRIDGE_PROTOCOL.md#3315-action-result)
- [ROS 2 GoalStatus](https://docs.ros2.org/latest/api/action_msgs/msg/GoalStatus.html)

If there is any issue, please let me know.

Fixes #889 
