### PR TITLE
Make `isConnected` a getter

### DIFF
--- a/src/core/Ros.ts
+++ b/src/core/Ros.ts
@@ -87,7 +87,7 @@ export default class Ros extends EventEmitter<
     }
   }
 
-  public isConnected(): boolean {
+  public get isConnected(): boolean {
     return this.#isConnected;
   }
 
@@ -188,7 +188,7 @@ export default class Ros extends EventEmitter<
    * If not connected, queues the message to send once reconnected.
    */
   public callOnConnection(message: RosbridgeMessage) {
-    if (this.isConnected()) {
+    if (this.isConnected) {
       this.transport?.send(message);
     } else {
       this.once("connection", () => {

--- a/test/ros.test.ts
+++ b/test/ros.test.ts
@@ -165,7 +165,7 @@ describe("Ros", function () {
         transportFactory: mockTransportFactory,
       });
 
-      expect(ros.isConnected()).toBe(false);
+      expect(ros.isConnected).toBe(false);
     });
 
     it("returns true when connected", async () => {
@@ -176,7 +176,7 @@ describe("Ros", function () {
       await ros.connect(mockRosUrl);
       publishMockTransportEvent("open", new Event("open"));
 
-      expect(ros.isConnected()).toBe(true);
+      expect(ros.isConnected).toBe(true);
     });
 
     it("returns false when disconnected", async () => {
@@ -188,7 +188,7 @@ describe("Ros", function () {
 
       mockTransport.close();
 
-      expect(ros.isConnected()).toBe(false);
+      expect(ros.isConnected).toBe(false);
     });
   });
 
@@ -204,7 +204,7 @@ describe("Ros", function () {
       ros.close();
 
       expect(mockTransport.close).toHaveBeenCalled();
-      expect(ros.isConnected()).toBe(false);
+      expect(ros.isConnected).toBe(false);
     });
 
     it("does not close the transport if it is already closed", () => {
@@ -215,7 +215,7 @@ describe("Ros", function () {
       ros.close();
 
       expect(mockTransport.close).not.toHaveBeenCalled();
-      expect(ros.isConnected()).toBe(false);
+      expect(ros.isConnected).toBe(false);
     });
   });
 

--- a/test/setup/ros-backend.ts
+++ b/test/setup/ros-backend.ts
@@ -42,7 +42,7 @@ async function waitForRosConnection(ros: Ros, timeout = 5000) {
     });
 
     // If already connected
-    if (ros.isConnected()) {
+    if (ros.isConnected) {
       clearTimeout(timeoutId);
       resolve();
     }


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->

Reverts the `isConnected` API to looking like a property, while preserving it as a function in case we need to add extra logic later.

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

^

<!-- Link relevant GitHub issues -->
