### PR TITLE
fix action example feedback message (for example_interfaces/Fibonacci type)

### DIFF
--- a/packages/roslib-examples/src/ros2_action_client.html
+++ b/packages/roslib-examples/src/ros2_action_client.html
@@ -56,7 +56,7 @@
             "Result for action goal on " +
               fibonacciClient.name +
               ": " +
-              result.result.sequence,
+              result.sequence,
           );
         },
         function (feedback) {
@@ -64,7 +64,7 @@
             "Feedback for action on " +
               fibonacciClient.name +
               ": " +
-              feedback.partial_sequence,
+              feedback.sequence,
           );
         },
       );

--- a/packages/roslib-examples/src/ros2_action_server.html
+++ b/packages/roslib-examples/src/ros2_action_server.html
@@ -34,7 +34,7 @@
             goal.order,
         );
         console.log("ID: " + id);
-        fibonacciSequence = [];
+        let fibonacciSequence = [];
         fibonacciSequence.push(0);
         fibonacciSequence.push(1);
 
@@ -54,7 +54,7 @@
           );
           console.log("Sending feedback: " + fibonacciSequence);
           fibonacciServer.sendFeedback(id, {
-            partial_sequence: fibonacciSequence,
+            sequence: fibonacciSequence,
           });
         }
 


### PR DESCRIPTION
**Public API Changes**
None

**Description**
The fibonacci type was chaged from action_tutorials_interfaces/Fibonacci to example_interfaces/Fibonacci in #955, which change the feedback name