### PR TITLE
chore: export GoalStatus

### DIFF
--- a/packages/roslib/src/RosLib.ts
+++ b/packages/roslib/src/RosLib.ts
@@ -11,7 +11,7 @@ export { default as Topic } from "./core/Topic.ts";
 export { default as Param } from "./core/Param.ts";
 export { default as Service } from "./core/Service.ts";
 export { default as Action } from "./core/Action.ts";
-export { type GoalStatus } from "./core/GoalStatus.ts";
+export { GoalStatus } from "./core/GoalStatus.ts";
 
 // Core Transport exports
 export {


### PR DESCRIPTION
**Public API Changes**
Made the `GoalStatus`' values public, so they may be initialized externally.


**Description**
This pull request allows for the Goal Status to be fully used externally, instead of only the type.


<!-- Link relevant GitHub issues -->
https://github.com/RobotWebTools/roslibjs/issues/1120