### PR TITLE
Add `Action.cancelAllGoals()`

### DIFF
--- a/packages/roslib/src/core/Action.ts
+++ b/packages/roslib/src/core/Action.ts
@@ -135,6 +135,17 @@ export default class Action<
   }
 
   /**
+   * Cancels all action goals.
+   */
+  cancelAllGoals() {
+    this.ros.callOnConnection({
+      op: "call_service",
+      service: `${this.name}/_action/cancel_goal`,
+      args: {},
+    });
+  }
+
+  /**
    * Advertise the action. This turns the Action object from a client
    * into a server. The callback will be called with every goal sent to this action.
    *

--- a/packages/roslib/test/examples/fibonacci.example.ts
+++ b/packages/roslib/test/examples/fibonacci.example.ts
@@ -1,65 +1,159 @@
 import { describe, it, expect } from "vitest";
 import * as ROSLIB from "../../src/RosLib.ts";
 
-// Noetic is the only version of ROS 1 we support, so we skip based on distro name
-// instead of adding extra plumbing for ROS_VERSION.
-describe.skipIf(process.env["ROS_DISTRO"] !== "noetic")(
-  "ROS 1 Fibonacci Example",
-  function () {
-    it(
-      "Fibonacci",
-      () =>
-        new Promise<void>((done) => {
-          const ros = new ROSLIB.Ros({
-            url: "ws://localhost:9090",
-          });
-          /*
-           * The ActionClient
-           * ----------------
-           */
+describe("Fibonacci Example", function () {
+  // Noetic is the only version of ROS 1 we support, so we skip based on distro name
+  // instead of adding extra plumbing for ROS_VERSION.
+  it.skipIf(process.env["ROS_DISTRO"] !== "noetic")(
+    "Fibonacci ROS 1",
+    () =>
+      new Promise<void>((done) => {
+        const ros = new ROSLIB.Ros({
+          url: "ws://localhost:9090",
+        });
+        /*
+         * The ActionClient
+         * ----------------
+         */
 
-          const fibonacciClient = new ROSLIB.ActionClient({
-            ros: ros,
-            serverName: "/fibonacci",
-            actionName: "actionlib_tutorials/FibonacciAction",
-          });
+        const fibonacciClient = new ROSLIB.ActionClient({
+          ros: ros,
+          serverName: "/fibonacci",
+          actionName: "actionlib_tutorials/FibonacciAction",
+        });
 
-          // Create a goal.
-          const goal = new ROSLIB.Goal({
-            actionClient: fibonacciClient,
-            goalMessage: {
-              order: 7,
-            },
-          });
+        // Create a goal.
+        const goal = new ROSLIB.Goal({
+          actionClient: fibonacciClient,
+          goalMessage: {
+            order: 7,
+          },
+        });
 
-          // Print out their output into the terminal.
-          const items = [
-            { sequence: [0, 1, 1] },
-            { sequence: [0, 1, 1, 2] },
-            { sequence: [0, 1, 1, 2, 3] },
-            { sequence: [0, 1, 1, 2, 3, 5] },
-            { sequence: [0, 1, 1, 2, 3, 5, 8] },
-            { sequence: [0, 1, 1, 2, 3, 5, 8, 13] },
-            { sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] },
-          ];
-          goal.on("feedback", function (feedback) {
-            expect(feedback).to.eql(items.shift());
-          });
-          goal.on("result", function (result) {
-            expect(result).to.eql({ sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] });
+        // Print out their output into the terminal.
+        const items = [
+          { sequence: [0, 1, 1] },
+          { sequence: [0, 1, 1, 2] },
+          { sequence: [0, 1, 1, 2, 3] },
+          { sequence: [0, 1, 1, 2, 3, 5] },
+          { sequence: [0, 1, 1, 2, 3, 5, 8] },
+          { sequence: [0, 1, 1, 2, 3, 5, 8, 13] },
+          { sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] },
+        ];
+        goal.on("feedback", function (feedback) {
+          expect(feedback).to.eql(items.shift());
+        });
+        goal.on("result", function (result) {
+          expect(result).to.eql({ sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] });
+          done();
+        });
+
+        /*
+         * Send the goal to the action server.
+         * The timeout is to allow rosbridge to properly subscribe all the
+         * Action topics - otherwise, the first feedback message might get lost
+         */
+        setTimeout(function () {
+          goal.send();
+        }, 100);
+      }),
+    8000,
+  );
+
+  it(
+    "Fibonacci ROS 2",
+    () =>
+      new Promise<void>((done) => {
+        const ros = new ROSLIB.Ros({
+          url: "ws://localhost:9090",
+        });
+        /*
+         * The ActionClient
+         * ----------------
+         */
+
+        const fibonacciAction = new ROSLIB.Action({
+          ros,
+          name: "/fibonacci",
+          actionType: "action_tutorials_interfaces/action/Fibonacci",
+        });
+
+        const goal = { order: 8 };
+
+        // Print out their output into the terminal.
+        const items = [
+          { sequence: [0, 1, 1] },
+          { sequence: [0, 1, 1, 2] },
+          { sequence: [0, 1, 1, 2, 3] },
+          { sequence: [0, 1, 1, 2, 3, 5] },
+          { sequence: [0, 1, 1, 2, 3, 5, 8] },
+          { sequence: [0, 1, 1, 2, 3, 5, 8, 13] },
+          { sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] },
+        ];
+
+        /*
+         * Send the goal to the action server.
+         */
+        fibonacciAction.sendGoal(
+          goal,
+          (result) => {
+            expect(result).to.eql({
+              sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21],
+            });
             done();
-          });
+          },
+          (feedback) => {
+            expect(feedback).to.eql(items.shift());
+          },
+        );
+      }),
+    8000,
+  );
 
-          /*
-           * Send the goal to the action server.
-           * The timeout is to allow rosbridge to properly subscribe all the
-           * Action topics - otherwise, the first feedback message might get lost
-           */
-          setTimeout(function () {
-            goal.send();
-          }, 100);
-        }),
-      8000,
+  it("Fibonacci ROS 2, cancel all goals", async () => {
+    const ros = new ROSLIB.Ros();
+    await ros.connect("ws://localhost:9090");
+
+    let resultCalled = false;
+    let failedCalled = false;
+
+    /*
+     * The Action
+     * ----------------
+     */
+    const fibonacciAction = new ROSLIB.Action({
+      ros,
+      name: "/fibonacci",
+      actionType: "action_tutorials_interfaces/action/Fibonacci",
+    });
+
+    const goal = { order: 8 };
+
+    /*
+     * Send the goal to the action server.
+     */
+    fibonacciAction.sendGoal(
+      goal,
+      // result callback.
+      () => {
+        resultCalled = true;
+      },
+      // feedback callback.
+      undefined,
+      // failed callback
+      () => {
+        failedCalled = true;
+      },
     );
-  },
-);
+
+    /*
+     * Cancel all goals.
+     */
+    fibonacciAction.cancelAllGoals();
+
+    setTimeout(() => {
+      expect(failedCalled).toBe(true);
+      expect(resultCalled).toBe(false);
+    }, 500); // wait 500ms to be sure the server handled the cancel request.
+  });
+});

--- a/packages/roslib/test/examples/fibonacci.example.ts
+++ b/packages/roslib/test/examples/fibonacci.example.ts
@@ -60,7 +60,7 @@ describe("Fibonacci Example", function () {
     8000,
   );
 
-  it(
+  it.skipIf(process.env["ROS_VERSION"] !== "2")(
     "Fibonacci ROS 2",
     () =>
       new Promise<void>((done) => {
@@ -110,50 +110,53 @@ describe("Fibonacci Example", function () {
     8000,
   );
 
-  it("Fibonacci ROS 2, cancel all goals", async () => {
-    const ros = new ROSLIB.Ros();
-    await ros.connect("ws://localhost:9090");
+  it.skipIf(process.env["ROS_VERSION"] !== "2")(
+    "Fibonacci ROS 2, cancel all goals",
+    async () => {
+      const ros = new ROSLIB.Ros();
+      await ros.connect("ws://localhost:9090");
 
-    let resultCalled = false;
-    let failedCalled = false;
+      let resultCalled = false;
+      let failedCalled = false;
 
-    /*
-     * The Action
-     * ----------------
-     */
-    const fibonacciAction = new ROSLIB.Action({
-      ros,
-      name: "/fibonacci",
-      actionType: "action_tutorials_interfaces/action/Fibonacci",
-    });
+      /*
+       * The Action
+       * ----------------
+       */
+      const fibonacciAction = new ROSLIB.Action({
+        ros,
+        name: "/fibonacci",
+        actionType: "action_tutorials_interfaces/action/Fibonacci",
+      });
 
-    const goal = { order: 8 };
+      const goal = { order: 8 };
 
-    /*
-     * Send the goal to the action server.
-     */
-    fibonacciAction.sendGoal(
-      goal,
-      // result callback.
-      () => {
-        resultCalled = true;
-      },
-      // feedback callback.
-      undefined,
-      // failed callback
-      () => {
-        failedCalled = true;
-      },
-    );
+      /*
+       * Send the goal to the action server.
+       */
+      fibonacciAction.sendGoal(
+        goal,
+        // result callback.
+        () => {
+          resultCalled = true;
+        },
+        // feedback callback.
+        undefined,
+        // failed callback
+        () => {
+          failedCalled = true;
+        },
+      );
 
-    /*
-     * Cancel all goals.
-     */
-    fibonacciAction.cancelAllGoals();
+      /*
+       * Cancel all goals.
+       */
+      fibonacciAction.cancelAllGoals();
 
-    setTimeout(() => {
-      expect(failedCalled).toBe(true);
-      expect(resultCalled).toBe(false);
-    }, 500); // wait 500ms to be sure the server handled the cancel request.
-  });
+      setTimeout(() => {
+        expect(failedCalled).toBe(true);
+        expect(resultCalled).toBe(false);
+      }, 500); // wait 500ms to be sure the server handled the cancel request.
+    },
+  );
 });

--- a/packages/roslib/test/examples/fibonacci.example.ts
+++ b/packages/roslib/test/examples/fibonacci.example.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from "vitest";
 import * as ROSLIB from "../../src/RosLib.ts";
 
+const fibonacciItems = [
+  { sequence: [0, 1, 1] },
+  { sequence: [0, 1, 1, 2] },
+  { sequence: [0, 1, 1, 2, 3] },
+  { sequence: [0, 1, 1, 2, 3, 5] },
+  { sequence: [0, 1, 1, 2, 3, 5, 8] },
+  { sequence: [0, 1, 1, 2, 3, 5, 8, 13] },
+  { sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] },
+];
+
 describe("Fibonacci Example", function () {
   // Noetic is the only version of ROS 1 we support, so we skip based on distro name
   // instead of adding extra plumbing for ROS_VERSION.
@@ -30,18 +40,8 @@ describe("Fibonacci Example", function () {
           },
         });
 
-        // Print out their output into the terminal.
-        const items = [
-          { sequence: [0, 1, 1] },
-          { sequence: [0, 1, 1, 2] },
-          { sequence: [0, 1, 1, 2, 3] },
-          { sequence: [0, 1, 1, 2, 3, 5] },
-          { sequence: [0, 1, 1, 2, 3, 5, 8] },
-          { sequence: [0, 1, 1, 2, 3, 5, 8, 13] },
-          { sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] },
-        ];
         goal.on("feedback", function (feedback) {
-          expect(feedback).to.eql(items.shift());
+          expect(feedback).to.eql(fibonacciItems.shift());
         });
         goal.on("result", function (result) {
           expect(result).to.eql({ sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] });
@@ -60,7 +60,7 @@ describe("Fibonacci Example", function () {
     8000,
   );
 
-  it.skipIf(process.env["ROS_VERSION"] !== "2")(
+  it.skipIf(process.env["ROS_DISTRO"] !== "humble")(
     "Fibonacci ROS 2",
     () =>
       new Promise<void>((done) => {
@@ -68,7 +68,7 @@ describe("Fibonacci Example", function () {
           url: "ws://localhost:9090",
         });
         /*
-         * The ActionClient
+         * The Action
          * ----------------
          */
 
@@ -79,17 +79,6 @@ describe("Fibonacci Example", function () {
         });
 
         const goal = { order: 8 };
-
-        // Print out their output into the terminal.
-        const items = [
-          { sequence: [0, 1, 1] },
-          { sequence: [0, 1, 1, 2] },
-          { sequence: [0, 1, 1, 2, 3] },
-          { sequence: [0, 1, 1, 2, 3, 5] },
-          { sequence: [0, 1, 1, 2, 3, 5, 8] },
-          { sequence: [0, 1, 1, 2, 3, 5, 8, 13] },
-          { sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21] },
-        ];
 
         /*
          * Send the goal to the action server.
@@ -103,14 +92,14 @@ describe("Fibonacci Example", function () {
             done();
           },
           (feedback) => {
-            expect(feedback).to.eql(items.shift());
+            expect(feedback).to.eql(fibonacciItems.shift());
           },
         );
       }),
     8000,
   );
 
-  it.skipIf(process.env["ROS_VERSION"] !== "2")(
+  it.skipIf(process.env["ROS_DISTRO"] !== "humble")(
     "Fibonacci ROS 2, cancel all goals",
     async () => {
       const ros = new ROSLIB.Ros();


### PR DESCRIPTION
The Ros1 ActionClient has the functionality that allows all goals to be canceled that were associated with the ActionClient. I thought this was very nice and useful, but missing in the Ros2 implementation of the Action / ActionClient.

Because I'm working on a project that allows for multiple users / clients to send goals and cancel those goals I don't have the correct goalID nor the means to really get it. Hence why I think this is useful.

**Changes:**
- Added cancelAllGoals -> cancels all goals for an action.
- Added integration tests
  - Added ROS2 fibonacci integration test based on the ROS1 fibonacci integration test. (There's an issue in the fibonacci server though; it doesn't return the correct order. But this doesn't change anything for the implementation of the test).
  - Added an integration test that verifies (based on fibonacci Action) that cancelAllGoals works, by checking whether failedCallback was invoked and not resultCallback.