### PR TITLE
feat: Add Promise-based `callServiceAsync` wrapper for async/await support

### DIFF
--- a/packages/roslib/src/core/Service.ts
+++ b/packages/roslib/src/core/Service.ts
@@ -96,6 +96,29 @@ export default class Service<
       timeout: timeout,
     });
   }
+
+  /**
+   * Wrapper of callService that returns a modern Promise-based interface for use with async/await.
+   * @see callService
+   * @param request - The service request to send.
+   * @param [timeout] - Optional timeout, in seconds, for the service call. A non-positive value means no timeout.
+   *                             If not provided, the rosbridge server will use its default value.
+   */
+  callServiceAsync(request: TRequest, timeout?: number): Promise<TResponse> {
+    return new Promise<TResponse>((resolve, reject) => {
+      this.callService(
+        request,
+        (res) => {
+          resolve(res);
+        },
+        (err) => {
+          reject(new Error(err));
+        },
+        timeout,
+      );
+    });
+  }
+
   /**
    * Advertise the service. This turns the Service object from a client
    * into a server. The callback will be called with every request

--- a/packages/roslib/test/service.test.ts
+++ b/packages/roslib/test/service.test.ts
@@ -204,23 +204,30 @@ describe("Service", () => {
     expect(server.isAdvertised).toBe(false);
   });
 
-  it("Successfully call /rosapi/get_time with an async return", async () => {
-    const emptyRequest = {};
-
-    const getTimeService = new Service<
-      typeof emptyRequest,
-      {
-        time: { sec: number; nanosec: number };
-      }
+  it("Successfully call a service with an asynchronous return", async () => {
+    const server = new Service<
+      undefined,
+      { success: boolean; message: string }
     >({
       ros,
-      serviceType: "rosapi_msgs/srv/GetTime",
-      name: "/rosapi/get_time",
+      serviceType: "std_srvs/Trigger",
+      name: "/test_service",
     });
+    await server.advertise((_request, response) => {
+      response.success = true;
+      response.message = "bar";
+      return true;
+    });
+    const client = new Service({
+      ros,
+      serviceType: "std_srvs/Trigger",
+      name: "/test_service",
+    });
+    const response = await client.callServiceAsync({});
 
-    const response = await getTimeService.callServiceAsync(emptyRequest);
-
-    expect(response.time.sec).toBeDefined();
-    expect(response.time.nanosec).toBeDefined();
+    expect(response).toEqual({
+      success: true,
+      message: "bar",
+    });
   });
 });

--- a/packages/roslib/test/service.test.ts
+++ b/packages/roslib/test/service.test.ts
@@ -229,5 +229,5 @@ describe("Service", () => {
       success: true,
       message: "bar",
     });
-  });
+  }, 10_000);
 });

--- a/packages/roslib/test/service.test.ts
+++ b/packages/roslib/test/service.test.ts
@@ -203,4 +203,24 @@ describe("Service", () => {
     await server.unadvertise();
     expect(server.isAdvertised).toBe(false);
   });
+
+  it("Successfully call /rosapi/get_time with an async return", async () => {
+    const emptyRequest = {};
+
+    const getTimeService = new Service<
+      typeof emptyRequest,
+      {
+        time: { sec: number; nanosec: number };
+      }
+    >({
+      ros,
+      serviceType: "rosapi_msgs/srv/GetTime",
+      name: "/rosapi/get_time",
+    });
+
+    const response = await getTimeService.callServiceAsync(emptyRequest);
+
+    expect(response.time.sec).toBeDefined();
+    expect(response.time.nanosec).toBeDefined();
+  });
 });


### PR DESCRIPTION
**Public API Changes**
Added `callServiceAsync` with a promise return. Which allows for cleaner usage.


for example: (response based on default srv implementation from:  (https://github.com/ros2/common_interfaces/tree/rolling/std_srvs/srv)
```ts
// Originally:
service.callService(
  request,
  (response) => {
    if (response.success) {
      console.log("request successful");
    } else {
      console.error("request failed");
    }
  },
  (failedCallbackString) => {
    console.error("request failed");
  }
);

// Which now may be replaced with:
try {
  const response = await service.callServiceAsync(request);
  
  if (response.success) {
    console.log("request successful");
  } else {
    console.error("request failed");
  }
} catch (error) {
  console.error("request failed");
}

```

In my opinion this is a lot more readable and a bit more normalized in the "typescript / javascript" world.
