### PR TITLE
fix path replacement for eventemitter3 for current and future versions

### DIFF
--- a/packages/roslib/package.json
+++ b/packages/roslib/package.json
@@ -64,7 +64,7 @@
     "test": "vitest",
     "prepublishOnly": "npm run test",
     "//": "The sed expression for eventemitter3 is because the package metadata is incorrect in EventEmitter3's package.json",
-    "generate-importmap": "jspm install --release --provider unpkg && sed -i.bak 's;eventemitter3@5.0.1/index.mjs;eventemitter3@5.0.1/dist/eventemitter3.esm.js;' importmap.js && rm importmap.js.bak",
+    "generate-importmap": "jspm install --release --provider unpkg && sed -i.bak 's;eventemitter3@\\([0-9.]\\+\\)/index.mjs;eventemitter3@\\1/dist/eventemitter3.esm.js;' importmap.js && rm importmap.js.bak",
     "prepare": "npm run build && npm run generate-importmap",
     "make-changelog": "changelog-maker RobotWebTools roslibjs --markdown | cat - CHANGELOG.md > NEW_CHANGELOG.md && mv NEW_CHANGELOG.md CHANGELOG.md"
   },


### PR DESCRIPTION
**Public API Changes**

None

**Description**

roslib depends on eventemitter3 version 5.0.1 **or newer** but generate-importmap is hardcoded for 5.0.1.
Currently, npm will install 5.0.4 which still requires this fix but won't get it, leading to failures when running roslib-examples (and likely all other packages using roslib).

<!-- Link relevant GitHub issues -->
